### PR TITLE
First pass implementation

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -45,12 +45,9 @@ jobs:
           override: true
       - run: cargo fetch
       - name: cargo test build
-        # Note the use of release here means longer compile time, but much
-        # faster test execution time. If you don't have any heavy tests it
-        # might be faster to take off release and just compile in debug
-        run: cargo build --tests --release
+        run: cargo build --tests
       - name: cargo test
-        run: cargo test --release
+        run: cargo test
 
   deny-check:
     name: cargo-deny
@@ -70,4 +67,7 @@ jobs:
           override: true
       - run: cargo fetch
       - name: cargo publish check
-        run: cargo publish --dry-run
+        run: |
+          cargo publish --dry-run --manifest-path exception-handler/Cargo.toml
+          cargo publish --dry-run --manifest-path minidumper/Cargo.toml
+          cargo publish --dry-run --manifest-path uctx/Cargo.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.dumps

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "minidump-writer"]
+	path = minidump-writer
+	url = https://github.com/EmbarkStudios/minidump_writer_linux.git
+	branch = changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
-members = ["exception-handler"]
+members = ["exception-handler", "minidumper", "uctx"]
+
+[profile.dev]
+debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
-members = ["exception-handler", "minidumper", "sadness-generator", "uctx"]
+members = [
+    "exception-handler",
+    "minidumper",
+    "minidumper-test",
+    "sadness-generator",
+    "uctx",
+]
 
 [profile.dev]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["exception-handler", "minidumper", "uctx"]
+members = ["exception-handler", "minidumper", "sadness-generator", "uctx"]
 
 [profile.dev]
 debug = 2

--- a/exception-handler/Cargo.toml
+++ b/exception-handler/Cargo.toml
@@ -9,3 +9,25 @@ license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/exception-handler"
 homepage = "https://github.com/EmbarkStudios/crash-handling/tree/main/exception-handler"
 keywords = ["breakpad", "minidump", "crash", "signal", "exception"]
+
+[dependencies]
+# Nicer handling of complex cfg expressions
+cfg-if = "1.0"
+# Nicer sync primitives
+parking_lot = "0.11"
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+# Wrapper around libc
+libc = "0.2"
+# Defines a few things not in libc
+nix = "0.23"
+# Portable ucontext replacement, particularly for musl
+uctx = { path = "../uctx" }
+
+[build-dependencies]
+# We use https://github.com/kaniini/libucontext to provide a full ucontext implementation
+# that also works when targetting musl, but it's C and asm so we need to build it
+cc = { version = "1.0", features = ["parallel"] }
+
+[dev-dependencies]
+minidump_writer_linux = { path = "../../minidump_writer_linux" }

--- a/exception-handler/Cargo.toml
+++ b/exception-handler/Cargo.toml
@@ -19,8 +19,6 @@ parking_lot = "0.11"
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 # Wrapper around libc
 libc = "0.2"
-# Defines a few things not in libc
-nix = "0.23"
 # Portable ucontext replacement, particularly for musl
 uctx = { path = "../uctx" }
 
@@ -30,4 +28,5 @@ uctx = { path = "../uctx" }
 cc = { version = "1.0", features = ["parallel"] }
 
 [dev-dependencies]
-minidump_writer_linux = { path = "../../minidump_writer_linux" }
+sadness-generator = { path = "../sadness-generator" }
+setjmp = "0.1"

--- a/exception-handler/Cargo.toml
+++ b/exception-handler/Cargo.toml
@@ -10,6 +10,12 @@ documentation = "https://docs.rs/exception-handler"
 homepage = "https://github.com/EmbarkStudios/crash-handling/tree/main/exception-handler"
 keywords = ["breakpad", "minidump", "crash", "signal", "exception"]
 
+[features]
+default = []
+# If enabled, will log out information when a signal is raised/exception thrown
+# but logged in a manner that is safe.
+debug-print = []
+
 [dependencies]
 # Nicer handling of complex cfg expressions
 cfg-if = "1.0"

--- a/exception-handler/LICENSE-APACHE
+++ b/exception-handler/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/exception-handler/LICENSE-MIT
+++ b/exception-handler/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2019 Embark Studios
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/exception-handler/src/error.rs
+++ b/exception-handler/src/error.rs
@@ -1,0 +1,33 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error {
+    OutOfMemory,
+    InvalidArgs,
+    Format(std::fmt::Error),
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Format(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutOfMemory => f.write_str("unable to allocate memory"),
+            Self::InvalidArgs => f.write_str("invalid arguments provided"),
+            Self::Format(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl From<std::fmt::Error> for Error {
+    fn from(e: std::fmt::Error) -> Self {
+        Self::Format(e)
+    }
+}

--- a/exception-handler/src/lib.rs
+++ b/exception-handler/src/lib.rs
@@ -89,6 +89,8 @@ cfg_if::cfg_if! {
     if #[cfg(unix)] {
         #[macro_use]
         pub mod unix;
+
+        pub use unix::write_stderr;
     }
 }
 

--- a/exception-handler/src/lib.rs
+++ b/exception-handler/src/lib.rs
@@ -1,1 +1,94 @@
+// BEGIN - Embark standard lints v5 for Rust 1.55+
+// do not change or add/remove here, but one can add exceptions after this section
+// for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+#![deny(unsafe_code)]
+#![warn(
+    clippy::all,
+    clippy::await_holding_lock,
+    clippy::char_lit_as_u8,
+    clippy::checked_conversions,
+    clippy::dbg_macro,
+    clippy::debug_assert_with_mut_call,
+    clippy::disallowed_method,
+    clippy::disallowed_type,
+    clippy::doc_markdown,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::exit,
+    clippy::expl_impl_clone_on_copy,
+    clippy::explicit_deref_methods,
+    clippy::explicit_into_iter_loop,
+    clippy::fallible_impl_from,
+    clippy::filter_map_next,
+    clippy::flat_map_option,
+    clippy::float_cmp_const,
+    clippy::fn_params_excessive_bools,
+    clippy::from_iter_instead_of_collect,
+    clippy::if_let_mutex,
+    clippy::implicit_clone,
+    clippy::imprecise_flops,
+    clippy::inefficient_to_string,
+    clippy::invalid_upcast_comparisons,
+    clippy::large_digit_groups,
+    clippy::large_stack_arrays,
+    clippy::large_types_passed_by_value,
+    clippy::let_unit_value,
+    clippy::linkedlist,
+    clippy::lossy_float_literal,
+    clippy::macro_use_imports,
+    clippy::manual_ok_or,
+    clippy::map_err_ignore,
+    clippy::map_flatten,
+    clippy::map_unwrap_or,
+    clippy::match_on_vec_items,
+    clippy::match_same_arms,
+    clippy::match_wild_err_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::mem_forget,
+    clippy::mismatched_target_os,
+    clippy::missing_enforced_import_renames,
+    clippy::mut_mut,
+    clippy::mutex_integer,
+    clippy::needless_borrow,
+    clippy::needless_continue,
+    clippy::needless_for_each,
+    clippy::option_option,
+    clippy::path_buf_push_overwrite,
+    clippy::ptr_as_ptr,
+    clippy::rc_mutex,
+    clippy::ref_option_ref,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::same_functions_in_if_condition,
+    clippy::semicolon_if_nothing_returned,
+    clippy::single_match_else,
+    clippy::string_add_assign,
+    clippy::string_add,
+    clippy::string_lit_as_bytes,
+    clippy::string_to_string,
+    clippy::todo,
+    clippy::trait_duplication_in_bounds,
+    clippy::unimplemented,
+    clippy::unnested_or_patterns,
+    clippy::unused_self,
+    clippy::useless_transmute,
+    clippy::verbose_file_reads,
+    clippy::zero_sized_map_values,
+    future_incompatible,
+    nonstandard_style,
+    rust_2018_idioms
+)]
+// END - Embark standard lints v0.5 for Rust 1.55+
+// crate-specific exceptions:
+#![allow(unsafe_code)]
 
+mod error;
+
+pub use error::Error;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(target_os = "linux", target_os = "android"))] {
+        pub mod linux;
+
+        pub use linux::{ExceptionHandler, CrashContext};
+    }
+}

--- a/exception-handler/src/lib.rs
+++ b/exception-handler/src/lib.rs
@@ -86,7 +86,15 @@ mod error;
 pub use error::Error;
 
 cfg_if::cfg_if! {
+    if #[cfg(unix)] {
+        #[macro_use]
+        pub mod unix;
+    }
+}
+
+cfg_if::cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "android"))] {
+        #[macro_use]
         pub mod linux;
 
         pub use linux::{ExceptionHandler, CrashContext, Signal, make_crash_event};

--- a/exception-handler/src/lib.rs
+++ b/exception-handler/src/lib.rs
@@ -89,6 +89,6 @@ cfg_if::cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "android"))] {
         pub mod linux;
 
-        pub use linux::{ExceptionHandler, CrashContext};
+        pub use linux::{ExceptionHandler, CrashContext, Signal};
     }
 }

--- a/exception-handler/src/lib.rs
+++ b/exception-handler/src/lib.rs
@@ -89,6 +89,6 @@ cfg_if::cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "android"))] {
         pub mod linux;
 
-        pub use linux::{ExceptionHandler, CrashContext, Signal};
+        pub use linux::{ExceptionHandler, CrashContext, Signal, make_crash_event};
     }
 }

--- a/exception-handler/src/linux.rs
+++ b/exception-handler/src/linux.rs
@@ -64,8 +64,7 @@ where
         F: Send + Sync + Fn(&CrashContext) -> bool,
     {
         fn on_crash(&self, context: &CrashContext) -> bool {
-        (self)(context)
-    }
+            debug_print!("inner...");
             (self.inner)(context)
         }
     }

--- a/exception-handler/src/linux.rs
+++ b/exception-handler/src/linux.rs
@@ -1,0 +1,119 @@
+mod state;
+
+use crate::Error;
+
+/// The full context for a crash
+pub struct CrashContext {
+    /// The signal info for the crash
+    pub siginfo: nix::sys::signalfd::siginfo,
+    /// The id of the crashing thread
+    pub tid: libc::pid_t,
+    /// Crashing thread context
+    pub context: uctx::ucontext_t,
+    /// Float state. This isn't part of the user ABI for Linux aarch, and is
+    /// already part of ucontext_t in mips
+    #[cfg(not(any(target_arch = "mips", target_arch = "arm")))]
+    pub float_state: uctx::fpregset_t,
+}
+
+unsafe impl Send for CrashContext {}
+
+pub trait CrashEvent: Send + Sync {
+    /// Method invoked when a crash occurs. Returning true indicates your handler
+    /// has processed the crash and that no further handlers should run.
+    fn on_crash(&self, context: &CrashContext) -> bool;
+}
+
+impl<F> CrashEvent for F
+where
+    F: Send + Sync + Fn(&CrashContext) -> bool,
+{
+    fn on_crash(&self, context: &CrashContext) -> bool {
+        (self)(context)
+    }
+}
+
+pub struct ExceptionHandler {
+    inner: std::sync::Arc<state::HandlerInner>,
+}
+
+impl ExceptionHandler {
+    /// Attaches a signal handler. The provided callback will be invoked if a
+    /// signal is caught, providing a [`CrashContext`] with the details of
+    /// the thread where the signal was thrown.
+    ///
+    /// The callback runs in a compromised context, so it is highly recommended
+    /// to not perform actions that may fail due to corrupted state that caused
+    /// or is a symptom of the original signal. This includes doing heap
+    /// allocations from the same allocator as the crashing code.
+    pub fn attach(on_crash: Box<dyn CrashEvent>) -> Result<Self, Error> {
+        unsafe {
+            state::install_sigaltstack()?;
+            state::install_handlers();
+        }
+
+        let inner = std::sync::Arc::new(state::HandlerInner::new(on_crash));
+
+        {
+            let mut handlers = state::HANDLER_STACK.lock();
+            handlers.push(std::sync::Arc::downgrade(&inner));
+        }
+
+        Ok(Self { inner })
+    }
+
+    /// Detaches this handler, removing it from the handler stack. This is done
+    /// automatically when this [`ExceptionHandler`] is dropped.
+    #[inline]
+    pub fn detach(self) {
+        self.do_detach();
+    }
+
+    /// Performs the actual
+    fn do_detach(&self) {
+        let mut handlers = state::HANDLER_STACK.lock();
+
+        if let Some(ind) = handlers.iter().position(|handler| {
+            handler.upgrade().map_or(false, |handler| {
+                std::sync::Arc::ptr_eq(&handler, &self.inner)
+            })
+        }) {
+            handlers.remove(ind);
+
+            if handlers.is_empty() {
+                unsafe {
+                    state::restore_sigaltstack();
+                    state::restore_handlers();
+                }
+            }
+        }
+    }
+
+    /// Sends the specified user signal.
+    pub fn simulate_signal(&self, signal: i32) -> bool {
+        // Normally this would be an unsafe function, since this unsafe encompasses
+        // the entirety of the body, however the user is really not required to
+        // uphold any guarantees on their end, so no real need to declare the
+        // function itself unsafe.
+        unsafe {
+            let mut siginfo: nix::sys::signalfd::siginfo = std::mem::zeroed();
+            siginfo.ssi_code = state::SI_USER;
+            siginfo.ssi_pid = std::process::id();
+
+            let mut context = std::mem::zeroed();
+            uctx::getcontext(&mut context);
+
+            self.inner.handle_signal(
+                signal,
+                &mut *(&mut siginfo as *mut nix::sys::signalfd::siginfo).cast::<libc::siginfo_t>(),
+                &mut *(&mut context as *mut uctx::ucontext_t).cast::<libc::c_void>(),
+            )
+        }
+    }
+}
+
+impl Drop for ExceptionHandler {
+    fn drop(&mut self) {
+        self.do_detach();
+    }
+}

--- a/exception-handler/src/linux.rs
+++ b/exception-handler/src/linux.rs
@@ -23,9 +23,8 @@ unsafe impl Send for CrashContext {}
 impl CrashContext {
     pub fn as_bytes(&self) -> &[u8] {
         unsafe {
-            eprintln!("msghdr {}", std::mem::size_of::<libc::msghdr>());
-            let size = dbg!(std::mem::size_of_val(self));
-            let ptr = self as *const Self as *const u8;
+            let size = std::mem::size_of_val(self);
+            let ptr = (self as *const Self).cast();
             std::slice::from_raw_parts(ptr, size)
         }
     }
@@ -162,7 +161,6 @@ impl ExceptionHandler {
 
 impl Drop for ExceptionHandler {
     fn drop(&mut self) {
-        println!("WAIT WTF IS DROP BEING CALLED");
         self.do_detach();
     }
 }

--- a/exception-handler/src/linux/state.rs
+++ b/exception-handler/src/linux/state.rs
@@ -1,0 +1,387 @@
+use crate::Error;
+use std::{mem, ptr};
+
+const MIN_STACK_SIZE: usize = 16 * 1024;
+/// kill
+pub(crate) const SI_USER: i32 = 0;
+/// tkill, tgkill
+const SI_TKILL: i32 = -6;
+
+struct StackSave {
+    old: Option<libc::stack_t>,
+    new: libc::stack_t,
+}
+
+unsafe impl Send for StackSave {}
+
+static STACK_SAVE: parking_lot::Mutex<Option<StackSave>> = parking_lot::const_mutex(None);
+
+/// Create an alternative stack to run the signal handlers on. This is done since
+/// the signal might have been caused by a stack overflow.
+pub unsafe fn install_sigaltstack() -> Result<(), Error> {
+    // Check to see if the existing sigaltstack, and if it exists, is it big
+    // enough. If so we don't need to allocate our own.
+    let mut old_stack = mem::zeroed();
+    let r = libc::sigaltstack(ptr::null(), &mut old_stack);
+    assert_eq!(
+        r,
+        0,
+        "learning about sigaltstack failed: {}",
+        std::io::Error::last_os_error()
+    );
+
+    if old_stack.ss_flags & libc::SS_DISABLE == 0 && old_stack.ss_size >= MIN_STACK_SIZE {
+        return Ok(());
+    }
+
+    // ... but failing that we need to allocate our own, so do all that
+    // here.
+    let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+    let guard_size = page_size;
+    let alloc_size = guard_size + MIN_STACK_SIZE;
+
+    let ptr = libc::mmap(
+        ptr::null_mut(),
+        alloc_size,
+        libc::PROT_NONE,
+        libc::MAP_PRIVATE | libc::MAP_ANON,
+        -1,
+        0,
+    );
+    if ptr == libc::MAP_FAILED {
+        return Err(Error::OutOfMemory);
+    }
+
+    // Prepare the stack with readable/writable memory and then register it
+    // with `sigaltstack`.
+    let stack_ptr = (ptr as usize + guard_size) as *mut libc::c_void;
+    let r = libc::mprotect(
+        stack_ptr,
+        MIN_STACK_SIZE,
+        libc::PROT_READ | libc::PROT_WRITE,
+    );
+    assert_eq!(
+        r,
+        0,
+        "mprotect to configure memory for sigaltstack failed: {}",
+        std::io::Error::last_os_error()
+    );
+    let new_stack = libc::stack_t {
+        ss_sp: stack_ptr,
+        ss_flags: 0,
+        ss_size: MIN_STACK_SIZE,
+    };
+    let r = libc::sigaltstack(&new_stack, ptr::null_mut());
+    assert_eq!(
+        r,
+        0,
+        "registering new sigaltstack failed: {}",
+        std::io::Error::last_os_error()
+    );
+
+    *STACK_SAVE.lock() = Some(StackSave {
+        old: (old_stack.ss_flags & libc::SS_DISABLE != 0).then(|| old_stack),
+        new: new_stack,
+    });
+
+    Ok(())
+}
+
+pub unsafe fn restore_sigaltstack() {
+    let mut ssl = STACK_SAVE.lock();
+
+    // Only restore the old_stack if the current alternative stack is the one
+    // installed by the call to install_sigaltstack.
+    if let Some(ss) = &mut *ssl {
+        let mut current_stack = mem::zeroed();
+        if libc::sigaltstack(ptr::null(), &mut current_stack) == -1 {
+            return;
+        }
+
+        if current_stack.ss_sp == ss.new.ss_sp {
+            if let Some(old) = ss.old {
+                // Restore the old alt stack if there was one
+                if libc::sigaltstack(&old, ptr::null_mut()) == -1 {
+                    return;
+                }
+            } else {
+                // Restore to the default alt stack otherwise
+                let mut disable: libc::stack_t = mem::zeroed();
+                disable.ss_flags = libc::SS_DISABLE;
+                if libc::sigaltstack(&disable, ptr::null_mut()) == -1 {
+                    return;
+                }
+            }
+        }
+
+        let r = libc::munmap(ss.new.ss_sp, ss.new.ss_size);
+        debug_assert_eq!(r, 0, "munmap failed during thread shutdown");
+        *ssl = None;
+    }
+}
+
+/// Restores the signal handler for the specified signal back to its original
+/// handler
+unsafe fn install_default_handler(sig: libc::c_int) {
+    // Android L+ expose signal and sigaction symbols that override the system
+    // ones. There is a bug in these functions where a request to set the handler
+    // to SIG_DFL is ignored. In that case, an infinite loop is entered as the
+    // signal is repeatedly sent to breakpad's signal handler.
+    // To work around this, directly call the system's sigaction.
+
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "android")] {
+            let mut sa: libc::sigaction = mem::zeroed();
+            libc::sigemptyset(&mut sa.sa_mask);
+            sa.sa_sigaction = libc::SIG_DFL;
+            sa.sa_flags = libc::SA_RESTART;
+            libc::syscall(
+                libc::SYS_rt_sigaction,
+                sig,
+                &sa,
+                ptr::null::<libc::sigaction>(),
+                mem::size_of::<libc::sigset_t>(),
+            );
+        } else {
+            libc::signal(sig, libc::SIG_DFL);
+        }
+    }
+}
+
+/// The various signals we attempt to handle
+const EXCEPTION_SIGNALS: [libc::c_int; 6] = [
+    libc::SIGSEGV,
+    libc::SIGABRT,
+    libc::SIGFPE,
+    libc::SIGILL,
+    libc::SIGBUS,
+    libc::SIGTRAP,
+];
+
+static OLD_HANDLERS: parking_lot::Mutex<Option<[libc::sigaction; 6]>> =
+    parking_lot::const_mutex(None);
+
+/// Restores all of the signal handlers back to their previous values, or the
+/// default if the previous value cannot be restored
+pub unsafe fn restore_handlers() {
+    let mut ohl = OLD_HANDLERS.lock();
+
+    if let Some(old) = &*ohl {
+        for (sig, action) in EXCEPTION_SIGNALS.into_iter().zip(old.iter()) {
+            if libc::sigaction(sig, action, ptr::null_mut()) == -1 {
+                install_default_handler(sig);
+            }
+        }
+    }
+
+    *ohl = None;
+}
+
+pub unsafe fn install_handlers() {
+    let mut ohl = OLD_HANDLERS.lock();
+
+    if ohl.is_some() {
+        return;
+    }
+
+    // Attempt store all of the current handlers so we can restore them later
+    let mut old_handlers: [mem::MaybeUninit<libc::sigaction>; 6] =
+        mem::MaybeUninit::uninit().assume_init();
+
+    for (sig, handler) in EXCEPTION_SIGNALS
+        .iter()
+        .copied()
+        .zip(old_handlers.iter_mut())
+    {
+        let mut old = mem::zeroed();
+        if libc::sigaction(sig, ptr::null(), &mut old) == -1 {
+            return;
+        }
+        *handler = mem::MaybeUninit::new(old);
+    }
+
+    let mut sa: libc::sigaction = mem::zeroed();
+    libc::sigemptyset(&mut sa.sa_mask);
+
+    // Mask all exception signals when we're handling one of them.
+    for sig in EXCEPTION_SIGNALS {
+        libc::sigaddset(&mut sa.sa_mask, sig);
+    }
+
+    sa.sa_sigaction = signal_handler as usize;
+    sa.sa_flags = libc::SA_ONSTACK | libc::SA_SIGINFO;
+
+    // Use our signal_handler for all of the signals we wish to catch
+    for sig in EXCEPTION_SIGNALS {
+        // At this point it is impractical to back out changes, and so failure to
+        // install a signal is intentionally ignored.
+        libc::sigaction(sig, &sa, ptr::null_mut());
+    }
+
+    // Everything is initialized. Transmute the array to the
+    // initialized type.
+    *ohl = Some(mem::transmute::<_, [libc::sigaction; 6]>(old_handlers));
+}
+
+pub(crate) static HANDLER_STACK: parking_lot::Mutex<Vec<std::sync::Weak<HandlerInner>>> =
+    parking_lot::const_mutex(Vec::new());
+
+unsafe extern "C" fn signal_handler(
+    sig: libc::c_int,
+    info: *mut libc::siginfo_t,
+    uc: *mut libc::c_void,
+) {
+    let info = &mut *info;
+    let uc = &mut *uc;
+
+    {
+        let handlers = HANDLER_STACK.lock();
+
+        // Sometimes, Breakpad runs inside a process where some other buggy code
+        // saves and restores signal handlers temporarily with 'signal'
+        // instead of 'sigaction'. This loses the SA_SIGINFO flag associated
+        // with this function. As a consequence, the values of 'info' and 'uc'
+        // become totally bogus, generally inducing a crash.
+        //
+        // The following code tries to detect this case. When it does, it
+        // resets the signal handlers with sigaction + SA_SIGINFO and returns.
+        // This forces the signal to be thrown again, but this time the kernel
+        // will call the function with the right arguments.
+        {
+            let mut cur_handler = mem::zeroed();
+            if libc::sigaction(sig, ptr::null_mut(), &mut cur_handler) == 0
+                && cur_handler.sa_sigaction == signal_handler as usize
+                && cur_handler.sa_flags & libc::SA_SIGINFO == 0
+            {
+                // Reset signal handler with the correct flags.
+                libc::sigemptyset(&mut cur_handler.sa_mask);
+                libc::sigaddset(&mut cur_handler.sa_mask, sig);
+
+                cur_handler.sa_sigaction = signal_handler as usize;
+                cur_handler.sa_flags = libc::SA_ONSTACK | libc::SA_SIGINFO;
+
+                if libc::sigaction(sig, &cur_handler, ptr::null_mut()) == -1 {
+                    // When resetting the handler fails, try to reset the
+                    // default one to avoid an infinite loop here.
+                    install_default_handler(sig);
+                }
+
+                // exit the handler as we should be called again soon
+                return;
+            }
+        }
+
+        let handled = (|| {
+            for handler in handlers.iter() {
+                if let Some(handler) = handler.upgrade() {
+                    if handler.handle_signal(sig, info, uc) {
+                        return true;
+                    }
+                }
+            }
+
+            false
+        })();
+
+        // Upon returning from this signal handler, sig will become unmasked and then
+        // it will be retriggered. If one of the ExceptionHandlers handled it
+        // successfully, restore the default handler. Otherwise, restore the
+        // previously installed handler. Then, when the signal is retriggered, it will
+        // be delivered to the appropriate handler.
+        if handled {
+            install_default_handler(sig);
+        } else {
+            restore_handlers();
+        }
+    }
+
+    if info.si_code <= 0 || sig == libc::SIGABRT {
+        // This signal was triggered by somebody sending us the signal with kill().
+        // In order to retrigger it, we have to queue a new signal by calling
+        // kill() ourselves.  The special case (si_pid == 0 && sig == SIGABRT) is
+        // due to the kernel sending a SIGABRT from a user request via SysRQ.
+        let tid = libc::gettid();
+        if libc::syscall(libc::SYS_tgkill, std::process::id(), tid, sig) < 0 {
+            // If we failed to kill ourselves (e.g. because a sandbox disallows us
+            // to do so), we instead resort to terminating our process. This will
+            // result in an incorrect exit code.
+            libc::_exit(1);
+        }
+    } else {
+        // This was a synchronous signal triggered by a hard fault (e.g. SIGSEGV).
+        // No need to reissue the signal. It will automatically trigger again,
+        // when we return from the signal handler.
+    }
+}
+
+/// The size of `CrashContext` can be too big w.r.t the size of alternatate stack
+/// for `signal_handler`. Keep the crash context as a .bss field.
+static CRASH_CONTEXT: parking_lot::Mutex<mem::MaybeUninit<super::CrashContext>> =
+    parking_lot::const_mutex(mem::MaybeUninit::uninit());
+
+pub(crate) struct HandlerInner {
+    handler: Box<dyn super::CrashEvent>,
+}
+
+impl HandlerInner {
+    #[inline]
+    pub(crate) fn new(handler: Box<dyn super::CrashEvent>) -> Self {
+        Self { handler }
+    }
+
+    pub(crate) unsafe fn handle_signal(
+        &self,
+        _sig: libc::c_int,
+        info: &mut libc::siginfo_t,
+        uc: &mut libc::c_void,
+    ) -> bool {
+        // The siginfo_t in libc is lowest common denominator, but this code is
+        // specifically targeting linux/android, which contains the si_pid field
+        // that we require
+        let nix_info = &*((info as *const libc::siginfo_t).cast::<nix::sys::signalfd::siginfo>());
+
+        // Allow ourselves to be dumped if the signal is trusted.
+        if info.si_code > 0
+            || ((info.si_code == SI_USER || info.si_code == SI_TKILL)
+                && nix_info.ssi_pid == std::process::id())
+        {
+            libc::syscall(libc::SYS_prctl, libc::PR_SET_DUMPABLE, 1, 0, 0, 0);
+        }
+
+        let mut crash_ctx = CRASH_CONTEXT.lock();
+
+        {
+            *crash_ctx = mem::MaybeUninit::zeroed();
+
+            let mut cc = &mut *crash_ctx.as_mut_ptr();
+
+            ptr::copy_nonoverlapping(nix_info, &mut cc.siginfo, 1);
+
+            let uc_ptr = &*(uc as *const libc::c_void).cast::<uctx::ucontext_t>();
+            ptr::copy_nonoverlapping(uc_ptr, &mut cc.context, 1);
+
+            cfg_if::cfg_if! {
+                if #[cfg(target_arch = "aarch64")] {
+                    let fp_ptr = uc_ptr.uc_mcontext.__reserved.cast::<libc::fpsimd_context>();
+
+                    if fp_ptr.head.magic == libc::FPSIMD_MAGIC {
+                        ptr::copy_nonoverlapping(fp_ptr, &mut cc.float_state, mem::size_of::<libc::_libc_fpstate>());
+                    }
+                } else if #[cfg(not(all(
+                    target_arch = "arm",
+                    target_arch = "mips",
+                    target_arch = "mips64")))] {
+                    if !uc_ptr.uc_mcontext.fpregs.is_null() {
+                        ptr::copy_nonoverlapping(uc_ptr.uc_mcontext.fpregs, ((&mut cc.float_state) as *mut uctx::fpregset_t).cast(), 1);
+
+                    }
+                } else {
+                }
+            }
+
+            cc.tid = libc::syscall(libc::SYS_gettid) as i32;
+        }
+
+        self.handler.on_crash(&*crash_ctx.as_ptr())
+    }
+}

--- a/exception-handler/src/linux/state.rs
+++ b/exception-handler/src/linux/state.rs
@@ -313,7 +313,7 @@ unsafe extern "C" fn signal_handler(
         // In order to retrigger it, we have to queue a new signal by calling
         // kill() ourselves.  The special case (si_pid == 0 && sig == SIGABRT) is
         // due to the kernel sending a SIGABRT from a user request via SysRQ.
-        let tid = libc::gettid();
+        let tid = libc::syscall(libc::SYS_gettid) as i32;
         if libc::syscall(libc::SYS_tgkill, std::process::id(), tid, sig) < 0 {
             // If we failed to kill ourselves (e.g. because a sandbox disallows us
             // to do so), we instead resort to terminating our process. This will

--- a/exception-handler/src/linux/state.rs
+++ b/exception-handler/src/linux/state.rs
@@ -121,6 +121,7 @@ pub unsafe fn restore_sigaltstack() {
 
 /// Restores the signal handler for the specified signal back to its original,
 /// default, handler
+#[inline]
 unsafe fn install_default_handler(sig: Signal) {
     set_handler(sig, libc::SIG_DFL);
 }

--- a/exception-handler/src/linux/state.rs
+++ b/exception-handler/src/linux/state.rs
@@ -358,10 +358,7 @@ impl HandlerInner {
             || ((info.si_code == SI_USER || info.si_code == SI_TKILL)
                 && nix_info.ssi_pid == std::process::id())
         {
-            debug_print!("setting dumpable");
-            assert!(libc::syscall(libc::SYS_prctl, libc::PR_SET_DUMPABLE, 1, 0, 0, 0) != -1);
-        } else {
-            debug_print!("oh no");
+            libc::syscall(libc::SYS_prctl, libc::PR_SET_DUMPABLE, 1, 0, 0, 0);
         }
 
         let mut crash_ctx = CRASH_CONTEXT.lock();

--- a/exception-handler/src/unix.rs
+++ b/exception-handler/src/unix.rs
@@ -1,0 +1,22 @@
+#[macro_export]
+macro_rules! cstr {
+    ($s:literal) => {{
+        concat!($s, "\n")
+    }};
+}
+
+#[macro_export]
+macro_rules! debug_print {
+    ($s:literal) => {
+        #[cfg(feature = "debug-print")]
+        {
+            let cstr = cstr!($s);
+            #[allow(unused_unsafe)]
+            unsafe {
+                libc::write(2, cstr.as_ptr().cast(), cstr.len());
+            }
+        }
+        #[cfg(not(feature = "debug-print"))]
+        {}
+    };
+}

--- a/exception-handler/src/unix.rs
+++ b/exception-handler/src/unix.rs
@@ -14,6 +14,7 @@ macro_rules! debug_print {
 
 /// Writes the specified string directly to stderr. This is safe to be called
 /// from within a compromised context.
+#[inline]
 pub fn write_stderr(s: &'static str) {
     unsafe {
         libc::write(2, s.as_ptr().cast(), s.len());

--- a/exception-handler/src/unix.rs
+++ b/exception-handler/src/unix.rs
@@ -1,22 +1,21 @@
-#[macro_export]
-macro_rules! cstr {
-    ($s:literal) => {{
-        concat!($s, "\n")
-    }};
-}
-
+#[cfg(feature = "debug-print")]
 #[macro_export]
 macro_rules! debug_print {
     ($s:literal) => {
-        #[cfg(feature = "debug-print")]
-        {
-            let cstr = cstr!($s);
-            #[allow(unused_unsafe)]
-            unsafe {
-                libc::write(2, cstr.as_ptr().cast(), cstr.len());
-            }
-        }
-        #[cfg(not(feature = "debug-print"))]
-        {}
+        let cstr = concat!($s, "\n");
+        $crate::write_stderr(cstr);
     };
+}
+
+#[cfg(not(feature = "debug-print"))]
+macro_rules! debug_print {
+    ($s:literal) => {};
+}
+
+/// Writes the specified string directly to stderr. This is safe to be called
+/// from within a compromised context.
+pub fn write_stderr(s: &str) {
+    unsafe {
+        libc::write(2, s.as_ptr().cast(), s.len());
+    }
 }

--- a/exception-handler/src/unix.rs
+++ b/exception-handler/src/unix.rs
@@ -14,7 +14,7 @@ macro_rules! debug_print {
 
 /// Writes the specified string directly to stderr. This is safe to be called
 /// from within a compromised context.
-pub fn write_stderr(s: &str) {
+pub fn write_stderr(s: &'static str) {
     unsafe {
         libc::write(2, s.as_ptr().cast(), s.len());
     }

--- a/exception-handler/tests/abort.rs
+++ b/exception-handler/tests/abort.rs
@@ -1,0 +1,6 @@
+mod shared;
+
+#[test]
+fn handles_abort() {
+    shared::handles_signal(shared::Signal::Abort, sadness_generator::raise_abort);
+}

--- a/exception-handler/tests/bus.rs
+++ b/exception-handler/tests/bus.rs
@@ -1,0 +1,12 @@
+mod shared;
+
+#[test]
+fn handles_bus() {
+    // TODO: for some reason raising an _actual_ SIGBUS with an unaligned
+    // memory access is _not_ sent to our signal handler at all, so for now
+    // just raise it manually and come back to this. This is _somewhat_ ok
+    // as SIGBUS is rarer compared to SIGSEGV
+    shared::handles_signal(shared::Signal::Bus, || unsafe {
+        libc::raise(shared::Signal::Bus as i32);
+    });
+}

--- a/exception-handler/tests/fpe.rs
+++ b/exception-handler/tests/fpe.rs
@@ -1,0 +1,9 @@
+mod shared;
+
+#[test]
+fn handles_fpe() {
+    shared::handles_signal(
+        shared::Signal::Fpe,
+        sadness_generator::raise_floating_point_exception,
+    );
+}

--- a/exception-handler/tests/illegal.rs
+++ b/exception-handler/tests/illegal.rs
@@ -1,0 +1,9 @@
+mod shared;
+
+#[test]
+fn handles_illegal_instruction() {
+    shared::handles_signal(
+        shared::Signal::Ill,
+        sadness_generator::raise_illegal_instruction,
+    );
+}

--- a/exception-handler/tests/segv.rs
+++ b/exception-handler/tests/segv.rs
@@ -1,0 +1,6 @@
+mod shared;
+
+#[test]
+fn handles_segv() {
+    shared::handles_signal(shared::Signal::Segv, sadness_generator::raise_segfault);
+}

--- a/exception-handler/tests/shared.rs
+++ b/exception-handler/tests/shared.rs
@@ -20,7 +20,7 @@ pub fn handles_signal(signal: Signal, raiser: impl Fn()) {
 
         if val == 0 {
             let got_it_in_handler = got_it.clone();
-            let tid = libc::gettid();
+            let tid = libc::syscall(libc::SYS_gettid) as i32;
 
             handler = Some(
                 exception_handler::ExceptionHandler::attach(exception_handler::make_crash_event(

--- a/exception-handler/tests/shared.rs
+++ b/exception-handler/tests/shared.rs
@@ -23,7 +23,7 @@ pub fn handles_signal(signal: Signal, raiser: impl Fn()) {
             let tid = libc::gettid();
 
             handler = Some(
-                exception_handler::ExceptionHandler::attach(Box::new(
+                exception_handler::ExceptionHandler::attach(exception_handler::make_crash_event(
                     move |cc: &exception_handler::CrashContext| {
                         assert_eq!(cc.siginfo.ssi_signo, signal as u32);
                         assert_eq!(cc.tid, tid);

--- a/exception-handler/tests/shared.rs
+++ b/exception-handler/tests/shared.rs
@@ -1,0 +1,57 @@
+pub use exception_handler::Signal;
+
+use std::{
+    mem::MaybeUninit,
+    sync::{self as ss, atomic},
+};
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn handles_signal(signal: Signal, raiser: impl Fn()) {
+    let got_it = ss::Arc::new(atomic::AtomicBool::new(false));
+    let mut handler = None;
+
+    unsafe {
+        let jmpbuf = ss::Arc::new(parking_lot::Mutex::new(MaybeUninit::uninit()));
+
+        // Set a jump point. The first time we are here we set up the signal
+        // handler and raise the signal, the signal handler jumps back to here
+        // and then we step over the initial block.
+        let val = setjmp::sigsetjmp(jmpbuf.lock().as_mut_ptr(), 1);
+
+        if val == 0 {
+            let got_it_in_handler = got_it.clone();
+            let tid = libc::gettid();
+
+            handler = Some(
+                exception_handler::ExceptionHandler::attach(Box::new(
+                    move |cc: &exception_handler::CrashContext| {
+                        assert_eq!(cc.siginfo.ssi_signo, signal as u32);
+                        assert_eq!(cc.tid, tid);
+
+                        // At least on linux these...aren't set. Which is weird
+                        //assert_eq!(cc.siginfo.ssi_pid, std::process::id());
+                        //assert_eq!(cc.siginfo.ssi_tid, tid as u32);
+
+                        got_it_in_handler.store(true, atomic::Ordering::Relaxed);
+
+                        // long jump back to before we crashed
+                        setjmp::siglongjmp(jmpbuf.lock().as_mut_ptr(), 1);
+
+                        //true
+                    },
+                ))
+                .unwrap(),
+            );
+
+            raiser();
+        }
+
+        assert!(got_it.load(atomic::Ordering::Relaxed));
+    }
+
+    // We can't actually clean up the handler since we long jump out of the signal
+    // handler, which leaves mutexes still locked since the stack is not unwound
+    // so if we don't just forget the hander we'll block infinitely waiting
+    // on mutex locks that will never be acquired
+    std::mem::forget(handler);
+}

--- a/exception-handler/tests/stack_overflow.rs
+++ b/exception-handler/tests/stack_overflow.rs
@@ -1,0 +1,9 @@
+mod shared;
+
+#[test]
+fn handles_stack_overflow() {
+    shared::handles_signal(
+        shared::Signal::Segv,
+        sadness_generator::raise_stack_overflow,
+    );
+}

--- a/exception-handler/tests/trap.rs
+++ b/exception-handler/tests/trap.rs
@@ -1,0 +1,6 @@
+mod shared;
+
+#[test]
+fn handles_trap() {
+    shared::handles_signal(shared::Signal::Trap, sadness_generator::raise_trap);
+}

--- a/minidumper-test/Cargo.toml
+++ b/minidumper-test/Cargo.toml
@@ -6,13 +6,19 @@ publish = false
 
 [[bin]]
 name = "crash-client"
-path = "src/bin.rs"
+path = "src/crash-client.rs"
+
+[[bin]]
+name = "crash-server"
+path = "src/crash-server.rs"
 
 [dependencies]
 anyhow = "1.0"
 clap = "3.0.0-beta.5"
 cfg-if = "1.0"
-exception-handler = { path = "../exception-handler" }
+exception-handler = { path = "../exception-handler", features = [
+    "debug-print",
+] }
 minidump = "0.9"
 minidumper = { path = "../minidumper" }
 notify-rust = "4.5"

--- a/minidumper-test/Cargo.toml
+++ b/minidumper-test/Cargo.toml
@@ -22,5 +22,6 @@ exception-handler = { path = "../exception-handler", features = [
 minidump = "0.9"
 minidumper = { path = "../minidumper" }
 notify-rust = "4.5"
+rayon = "1.5"
 sadness-generator = { path = "../sadness-generator" }
 tracing-subscriber = { version = "0.3" }

--- a/minidumper-test/Cargo.toml
+++ b/minidumper-test/Cargo.toml
@@ -12,7 +12,9 @@ path = "src/bin.rs"
 anyhow = "1.0"
 assert_cmd = "2.0"
 clap = "3.0.0-beta.5"
+cfg-if = "1.0"
 exception-handler = { path = "../exception-handler" }
+minidump = "0.9"
 minidumper = { path = "../minidumper" }
 predicates = "2.0"
 sadness-generator = { path = "../sadness-generator" }

--- a/minidumper-test/Cargo.toml
+++ b/minidumper-test/Cargo.toml
@@ -5,17 +5,16 @@ edition = "2021"
 publish = false
 
 [[bin]]
-name = "client"
+name = "crash-client"
 path = "src/bin.rs"
 
 [dependencies]
 anyhow = "1.0"
-assert_cmd = "2.0"
 clap = "3.0.0-beta.5"
 cfg-if = "1.0"
 exception-handler = { path = "../exception-handler" }
 minidump = "0.9"
 minidumper = { path = "../minidumper" }
-predicates = "2.0"
+notify-rust = "4.5"
 sadness-generator = { path = "../sadness-generator" }
 tracing-subscriber = { version = "0.3" }

--- a/minidumper-test/Cargo.toml
+++ b/minidumper-test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "minidumper-test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "minidumper-test"
+path = "src/bin.rs"
+
+[dependencies]
+clap = "3.0.0-beta.5"
+exception-handler = { path = "../exception-handler" }
+minidumper = { path = "../minidumper" }
+sadness-generator = { path = "../sadness-generator" }

--- a/minidumper-test/Cargo.toml
+++ b/minidumper-test/Cargo.toml
@@ -5,11 +5,15 @@ edition = "2021"
 publish = false
 
 [[bin]]
-name = "minidumper-test"
+name = "client"
 path = "src/bin.rs"
 
 [dependencies]
+anyhow = "1.0"
+assert_cmd = "2.0"
 clap = "3.0.0-beta.5"
 exception-handler = { path = "../exception-handler" }
 minidumper = { path = "../minidumper" }
+predicates = "2.0"
 sadness-generator = { path = "../sadness-generator" }
+tracing-subscriber = { version = "0.3" }

--- a/minidumper-test/src/bin.rs
+++ b/minidumper-test/src/bin.rs
@@ -33,7 +33,7 @@ fn real_main() -> anyhow::Result<()> {
         }
     };
 
-    let handler = exception_handler::ExceptionHandler::attach(Box::new(
+    let _handler = exception_handler::ExceptionHandler::attach(Box::new(
         move |cc: &exception_handler::CrashContext| {
             println!("requesting dump");
             let res = dbg!(md_client.request_dump(cc));
@@ -75,10 +75,7 @@ fn real_main() -> anyhow::Result<()> {
         raise_signal();
     }
 
-    // We won't get here, but still
-    drop(handler);
-
-    Ok(())
+    anyhow::bail!("we should have raised a signal and exited");
 }
 
 fn main() {

--- a/minidumper-test/src/bin.rs
+++ b/minidumper-test/src/bin.rs
@@ -1,0 +1,62 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+struct Command {
+    /// Identifier for the client or server, this is required since for tests
+    /// we spawn multiple simultaneous processes and want each one to get its
+    /// own socket
+    #[clap(long)]
+    id: String,
+    /// The directory where the minidump will be written
+    #[clap(short)]
+    dump_dir: PathBuf,
+    #[clap(subcommand)]
+    sub: Subcommand,
+}
+
+#[derive(clap::ArgEnum, Clone, Copy)]
+enum Signal {
+    IllegalInstruction,
+    Trap,
+    Abort,
+    Bus,
+    Fpe,
+    Segv,
+}
+
+#[derive(Parser)]
+enum Subcommand {
+    /// Runs the client, which will spawn the server automatically and connect
+    /// to it before raising the specified signal
+    Client {
+        /// The signal/exception to raise
+        #[clap(possible_values = &Signal::variants())]
+        signal: Signal,
+    },
+    /// Runs the server which is responsible for actually creating a minidump
+    /// of the "faulty" client process
+    Server,
+}
+
+fn main() {
+    let cmd = Command::parse();
+
+    match cmd.sub {
+        Subcommand::Client { signal } => {
+            let mut server_cmd = std::process::Command::new(
+                std::env::current_exe().expect("unable to retrieve current executable"),
+            );
+            server_cmd.args(&[
+                "--id",
+                &cmd.id,
+                "-d",
+                &cmd.dump_dir.to_str().expect("non utf-8 dump directory"),
+                "server",
+            ]);
+
+            server_cmd.spawn();
+        }
+        Subcommand::Server => {}
+    }
+}

--- a/minidumper-test/src/crash-client.rs
+++ b/minidumper-test/src/crash-client.rs
@@ -53,10 +53,7 @@ fn real_main() -> anyhow::Result<()> {
 
     let _handler = exception_handler::ExceptionHandler::attach(unsafe {
         exception_handler::make_crash_event(move |cc: &exception_handler::CrashContext| {
-            // println!, that one cool trick to segfault your signal handler!
-            //println!("requesting dump"); DON'T DO THIS
-            md_client.request_dump(cc).is_ok()
-            //true
+            md_client.request_dump(cc, true).is_ok()
         })
     });
 

--- a/minidumper-test/src/crash-server.rs
+++ b/minidumper-test/src/crash-server.rs
@@ -1,0 +1,21 @@
+use clap::Parser;
+
+#[derive(Parser)]
+struct Command {
+    /// The unique identifier for the socket connection and the minidump file
+    /// that should be produced when this clietn
+    #[clap(long)]
+    id: String,
+}
+
+fn main() {
+    let cmd = Command::parse();
+
+    println!("pid: {}", std::process::id());
+
+    let server = minidumper_test::spinup_server(&cmd.id);
+
+    let dump_path = server.dump_rx.recv().expect("failed to receive dump path");
+
+    println!("dump written to {}", dump_path.display());
+}

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -1,0 +1,155 @@
+#[derive(clap::ArgEnum, Clone, Copy)]
+pub enum Signal {
+    Illegal,
+    Trap,
+    Abort,
+    Bus,
+    Fpe,
+    Segv,
+    StackOverflow,
+}
+
+use std::fmt;
+impl fmt::Display for Signal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Illegal => "illegal",
+            Self::Trap => "trap",
+            Self::Abort => "abort",
+            Self::Bus => "bus",
+            Self::Fpe => "fpe",
+            Self::Segv => "segv",
+            Self::StackOverflow => "stack-overflow",
+        })
+    }
+}
+
+use std::{
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc, Mutex,
+    },
+};
+
+pub struct Server {
+    pub id: String,
+    pub dump_rx: mpsc::Receiver<PathBuf>,
+    exit_run_loop: Arc<AtomicBool>,
+    run_loop: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.exit_run_loop.store(true, Ordering::Relaxed);
+        if let Some(jh) = self.run_loop.take() {
+            jh.join().expect("failed to join server thread");
+        }
+    }
+}
+
+#[inline]
+fn make_dump_path(id: &str) -> PathBuf {
+    PathBuf::from(format!(".dumps/{}.dmp", id))
+}
+
+pub fn spinup_server(id: &str) -> Server {
+    let dump_path = make_dump_path(id);
+
+    if dump_path.exists() {
+        if let Err(e) = std::fs::remove_file(&dump_path) {
+            panic!(
+                "failed to remove existing dump file {}: {}",
+                dump_path.display(),
+                e
+            );
+        }
+    }
+
+    let server = minidumper::Server::with_name(id).expect("failed to start server");
+
+    struct Inner {
+        id: String,
+        dump_tx: Mutex<mpsc::Sender<PathBuf>>,
+    }
+
+    impl minidumper::ServerHandler for Inner {
+        fn create_minidump_file(&self) -> Result<(std::fs::File, PathBuf), std::io::Error> {
+            let path = make_dump_path(&self.id);
+            let file = std::fs::File::create(&path)?;
+
+            Ok((file, path))
+        }
+
+        fn on_minidump_created(
+            &self,
+            result: Result<minidumper::MinidumpBinary, minidumper::Error>,
+        ) {
+            let md_bin = result.expect("failed to write minidump");
+            md_bin
+                .file
+                .sync_all()
+                .expect("failed to flush minidump file");
+
+            self.dump_tx
+                .lock()
+                .expect("unable to acquire lock")
+                .send(md_bin.path)
+                .expect("couldn't send minidump path");
+        }
+
+        fn on_message(&self, _kind: u32, _buffer: Vec<u8>) {
+            unimplemented!();
+        }
+    }
+
+    let (tx, rx) = mpsc::channel();
+
+    let inner = Inner {
+        id: id.to_owned(),
+        dump_tx: Mutex::new(tx),
+    };
+
+    let exit = Arc::new(AtomicBool::new(false));
+    let exit_run_loop = exit.clone();
+
+    let run_loop = std::thread::spawn(move || {
+        server
+            .run(Box::new(inner), &exit)
+            .expect("failed to run server loop");
+    });
+
+    Server {
+        id: id.to_owned(),
+        dump_rx: rx,
+        exit_run_loop,
+        run_loop: Some(run_loop),
+    }
+}
+
+pub fn run_client(id: &str, signal: Signal, use_thread: bool) {
+    use assert_cmd::Command;
+
+    let mut cmd = Command::cargo_bin("client").unwrap();
+    cmd.args(&["--id", id, "--signal", &signal.to_string()]);
+    if use_thread {
+        cmd.arg("--use-thread");
+    }
+
+    let assert = cmd.assert().interrupted();
+    let output = assert.get_output();
+
+    let stdout = std::str::from_utf8(&output.stdout).expect("invalid stdout");
+    let stderr = std::str::from_utf8(&output.stderr).expect("invalid stderr");
+
+    println!("{}", stdout);
+    eprintln!("{}", stderr);
+}
+
+pub fn capture_output() {
+    static SUB: std::sync::Once = std::sync::Once::new();
+
+    SUB.call_once(|| {
+        tracing_subscriber::fmt().with_test_writer().init();
+    })
+}

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -244,7 +244,10 @@ pub fn get_native_cpu() -> Cpu {
 }
 
 pub fn assert_minidump(md_buf: &[u8], signal: Signal) {
-    use minidump::{format::ExceptionCodeLinux, CrashReason};
+    use minidump::{
+        format::{ExceptionCodeLinux, ExceptionCodeLinuxSigbusKind},
+        CrashReason,
+    };
 
     let md = minidump::Minidump::read(md_buf).expect("failed to parse minidump");
 
@@ -262,6 +265,12 @@ pub fn assert_minidump(md_buf: &[u8], signal: Signal) {
                 assert!(matches!(
                     crash_reason,
                     CrashReason::LinuxGeneral(ExceptionCodeLinux::SIGABRT, _)
+                ));
+            }
+            Signal::Bus => {
+                assert!(matches!(
+                    crash_reason,
+                    CrashReason::LinuxSigbus(ExceptionCodeLinuxSigbusKind::BUS_ADRALN)
                 ));
             }
             _ => unimplemented!(),

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -278,3 +278,11 @@ pub fn assert_minidump(md_buf: &[u8], signal: Signal) {
         _ => unimplemented!(),
     }
 }
+
+pub fn run_threaded_test(signal: Signal, count: u32) {
+    use rayon::prelude::*;
+
+    (0..count).into_par_iter().for_each(|i| {
+        run_test(signal, i, true);
+    });
+}

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -102,7 +102,7 @@ pub fn spinup_server(id: &str) -> Server {
         fn on_minidump_created(
             &self,
             result: Result<minidumper::MinidumpBinary, minidumper::Error>,
-        ) {
+        ) -> bool {
             let md_bin = result.expect("failed to write minidump");
             md_bin
                 .file
@@ -114,6 +114,8 @@ pub fn spinup_server(id: &str) -> Server {
                 .expect("unable to acquire lock")
                 .send(md_bin.path)
                 .expect("couldn't send minidump path");
+
+            false
         }
 
         fn on_message(&self, _kind: u32, _buffer: Vec<u8>) {

--- a/minidumper-test/tests/abort.rs
+++ b/minidumper-test/tests/abort.rs
@@ -2,12 +2,12 @@ use minidumper_test::*;
 
 #[test]
 fn abort_simple() {
-    run_test(Signal::Abort, 0, false);
+    run_test(Signal::Abort, 0, true);
 }
 
 #[test]
 fn abort_threaded() {
-    for i in 0..32 {
-        run_test(Signal::Abort, i, true);
-    }
+    //for i in 0..32 {
+    //run_test(Signal::Abort, 0, true);
+    //}
 }

--- a/minidumper-test/tests/abort.rs
+++ b/minidumper-test/tests/abort.rs
@@ -1,0 +1,24 @@
+use minidumper_test::*;
+
+#[test]
+fn abort() {
+    capture_output();
+
+    let server = spinup_server("abort-simple");
+    run_client("abort-simple", Signal::Abort, false);
+
+    let dump_path = server
+        .dump_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .expect("failed to receive dump path");
+
+    assert!(
+        std::fs::metadata(&dump_path)
+            .expect("failed to read minidump")
+            .len()
+            > 1024
+    );
+}
+
+#[test]
+fn abort_threaded() {}

--- a/minidumper-test/tests/abort.rs
+++ b/minidumper-test/tests/abort.rs
@@ -7,7 +7,5 @@ fn abort_simple() {
 
 #[test]
 fn abort_threaded() {
-    //for i in 0..32 {
-    //run_test(Signal::Abort, 0, true);
-    //}
+    run_threaded_test(Signal::Abort, 32);
 }

--- a/minidumper-test/tests/abort.rs
+++ b/minidumper-test/tests/abort.rs
@@ -2,7 +2,7 @@ use minidumper_test::*;
 
 #[test]
 fn abort_simple() {
-    run_test(Signal::Abort, 0, true);
+    run_test(Signal::Abort, 0, false);
 }
 
 #[test]

--- a/minidumper-test/tests/abort.rs
+++ b/minidumper-test/tests/abort.rs
@@ -2,14 +2,12 @@ use minidumper_test::*;
 
 #[test]
 fn abort_simple() {
-    let md = generate_minidump("abort-simple", Signal::Abort, false);
-
-    assert_minidump(&md, Signal::Abort);
+    run_test(Signal::Abort, 0, false);
 }
 
 #[test]
 fn abort_threaded() {
-    let md = generate_minidump("abort-threaded", Signal::Abort, true);
-
-    assert_minidump(&md, Signal::Abort);
+    for i in 0..32 {
+        run_test(Signal::Abort, i, true);
+    }
 }

--- a/minidumper-test/tests/abort.rs
+++ b/minidumper-test/tests/abort.rs
@@ -1,24 +1,15 @@
 use minidumper_test::*;
 
 #[test]
-fn abort() {
-    capture_output();
+fn abort_simple() {
+    let md = generate_minidump("abort-simple", Signal::Abort, false);
 
-    let server = spinup_server("abort-simple");
-    run_client("abort-simple", Signal::Abort, false);
-
-    let dump_path = server
-        .dump_rx
-        .recv_timeout(std::time::Duration::from_secs(1))
-        .expect("failed to receive dump path");
-
-    assert!(
-        std::fs::metadata(&dump_path)
-            .expect("failed to read minidump")
-            .len()
-            > 1024
-    );
+    assert_minidump(&md, Signal::Abort);
 }
 
 #[test]
-fn abort_threaded() {}
+fn abort_threaded() {
+    let md = generate_minidump("abort-threaded", Signal::Abort, true);
+
+    assert_minidump(&md, Signal::Abort);
+}

--- a/minidumper-test/tests/bus.rs
+++ b/minidumper-test/tests/bus.rs
@@ -7,7 +7,5 @@ fn bus_simple() {
 
 #[test]
 fn bus_threaded() {
-    for i in 0..32 {
-        run_test(Signal::Bus, i, true);
-    }
+    run_threaded_test(Signal::Bus, 32);
 }

--- a/minidumper-test/tests/bus.rs
+++ b/minidumper-test/tests/bus.rs
@@ -1,0 +1,13 @@
+use minidumper_test::*;
+
+#[test]
+fn bus_simple() {
+    run_test(Signal::Bus, 0, false);
+}
+
+#[test]
+fn bus_threaded() {
+    for i in 0..32 {
+        run_test(Signal::Bus, i, true);
+    }
+}

--- a/minidumper-test/tests/fpe.rs
+++ b/minidumper-test/tests/fpe.rs
@@ -1,0 +1,11 @@
+use minidumper_test::*;
+
+#[test]
+fn fpe_simple() {
+    run_test(Signal::Fpe, 0, false);
+}
+
+#[test]
+fn fpe_threaded() {
+    run_threaded_test(Signal::Fpe, 32);
+}

--- a/minidumper-test/tests/illegal.rs
+++ b/minidumper-test/tests/illegal.rs
@@ -1,0 +1,11 @@
+use minidumper_test::*;
+
+#[test]
+fn illegal_simple() {
+    run_test(Signal::Illegal, 0, false);
+}
+
+#[test]
+fn illegal_threaded() {
+    run_threaded_test(Signal::Illegal, 32);
+}

--- a/minidumper-test/tests/segfault.rs
+++ b/minidumper-test/tests/segfault.rs
@@ -1,0 +1,11 @@
+use minidumper_test::*;
+
+#[test]
+fn segfault_simple() {
+    run_test(Signal::Segv, 0, false);
+}
+
+#[test]
+fn segfault_threaded() {
+    run_threaded_test(Signal::Segv, 32);
+}

--- a/minidumper-test/tests/stack_overflow.rs
+++ b/minidumper-test/tests/stack_overflow.rs
@@ -1,0 +1,11 @@
+use minidumper_test::*;
+
+#[test]
+fn stack_overflow_simple() {
+    run_test(Signal::StackOverflow, 0, false);
+}
+
+#[test]
+fn stack_overflow_threaded() {
+    run_threaded_test(Signal::StackOverflow, 32);
+}

--- a/minidumper-test/tests/trap.rs
+++ b/minidumper-test/tests/trap.rs
@@ -1,0 +1,11 @@
+use minidumper_test::*;
+
+#[test]
+fn trap_simple() {
+    run_test(Signal::Trap, 0, false);
+}
+
+#[test]
+fn trap_threaded() {
+    run_threaded_test(Signal::Trap, 32);
+}

--- a/minidumper/Cargo.toml
+++ b/minidumper/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 cfg-if = "1.0"
 log = "0.4"
 thiserror = "1.0"
+exception-handler = { path = "../exception-handler", features = [
+    "debug-print",
+] }
 # Minidump writing (currently linux/android only)
 #minidump_writer_linux = { git = "https://github.com/EmbarkStudios/minidump_writer_linux", branch = "changes" }
 minidump-writer = { path = "../../minidump_writer_linux" }

--- a/minidumper/Cargo.toml
+++ b/minidumper/Cargo.toml
@@ -4,15 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# Nicer cfg handling
 cfg-if = "1.0"
+libc = "0.2"
+# Basic log emitting
 log = "0.4"
+# Nicer error creation
 thiserror = "1.0"
-exception-handler = { path = "../exception-handler", features = [
-    "debug-print",
-] }
 # Minidump writing (currently linux/android only)
-#minidump_writer_linux = { git = "https://github.com/EmbarkStudios/minidump_writer_linux", branch = "changes" }
-minidump-writer = { path = "../../minidump_writer_linux" }
+#minidump-writer = { git = "https://github.com/EmbarkStudios/minidump_writer_linux", rev = "7e6f130" }
+minidump-writer = { path = "../minidump-writer" }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 # Event loop for uds

--- a/minidumper/Cargo.toml
+++ b/minidumper/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 cfg-if = "1.0"
 log = "0.4"
 thiserror = "1.0"
+# Minidump writing (currently linux/android only)
+#minidump_writer_linux = { git = "https://github.com/EmbarkStudios/minidump_writer_linux", branch = "changes" }
+minidump-writer = { path = "../../minidump_writer_linux" }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-# Minidump writing for linux
-#minidump_writer_linux = { git = "https://github.com/EmbarkStudios/minidump_writer_linux", branch = "changes" }
-minidump_writer_linux = { path = "../../minidump_writer_linux" }
 # Event loop for uds
 mio = "0.7"
 # Improved Unix domain socket support, includes features that are not available in std

--- a/minidumper/Cargo.toml
+++ b/minidumper/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "minidumper"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cfg-if = "1.0"
+log = "0.4"
+thiserror = "1.0"
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+# Minidump writing for linux
+#minidump_writer_linux = { git = "https://github.com/EmbarkStudios/minidump_writer_linux", branch = "changes" }
+minidump_writer_linux = { path = "../../minidump_writer_linux" }
+# Event loop for uds
+mio = "0.7"
+# Improved Unix domain socket support, includes features that are not available in std
+uds = { version = "0.2.6", features = ["mio_07"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+# Named pipe support, though Windows 10+ does support Unix domain sockets
+named_pipe = "0.4"
+
+[dev-dependencies]
+# catching crashes to request minidumps
+exception-handler = { path = "../exception-handler" }
+# uuid generation
+uuid = { version = "0.8", features = ["v4"] }
+backtrace = "0.3"

--- a/minidumper/LICENSE-APACHE
+++ b/minidumper/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/minidumper/LICENSE-MIT
+++ b/minidumper/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2019 Embark Studios
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -85,12 +85,10 @@ fn main() {
             client.send_message(std::num::NonZeroU32::new(1).unwrap(), "mistakes will be made").unwrap();
 
             let handler = exception_handler::ExceptionHandler::attach(unsafe {exception_handler::make_crash_event(move |crash_context: &exception_handler::CrashContext| {
-                //log::error!("OH NO");
-
                 // Before we request the crash, send a message to the server
                 client.send_message(std::num::NonZeroU32::new(2).unwrap(), "mistakes were made").unwrap();
 
-                client.request_dump(crash_context).is_ok()
+                client.request_dump(crash_context, true).is_ok()
             })}).expect("failed to attach signal handler");
 
             handler.simulate_signal(exception_handler::Signal::Segv);

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -64,33 +64,18 @@ fn main() {
             break client;
         }
 
-        // let exe = std::env::current_exe().expect("unable to find ourselves");
+        let exe = std::env::current_exe().expect("unable to find ourselves");
 
-        // _server_proc = Some(
-        //     std::process::Command::new(exe)
-        //         .arg("--server")
-        //         .spawn()
-        //         .expect("unable to spawn server process"),
-        // );
+        _server_proc = Some(
+            std::process::Command::new(exe)
+                .arg("--server")
+                .spawn()
+                .expect("unable to spawn server process"),
+        );
 
-        // // Give it time to start
-        // std::thread::sleep(std::time::Duration::from_millis(100));
+        // Give it time to start
+        std::thread::sleep(std::time::Duration::from_millis(100));
     };
-
-    // Makes a sad
-    fn sigsegv() {
-        let s: &u32 = unsafe {
-            // avoid deref_nullptr lint
-            #[inline]
-            fn get_ptr() -> *const u32 {
-                std::ptr::null()
-            }
-            &*get_ptr()
-        };
-
-        log::info!("backtrace: {:#?}", backtrace::Backtrace::new());
-        println!("we are crashing by accessing a null reference: {}", *s);
-    }
 
     // Register our exception handler
     cfg_if::cfg_if! {
@@ -106,11 +91,7 @@ fn main() {
                 dbg!(client.request_dump(crash_context).is_ok())
             })).expect("failed to attach signal handler");
 
-            std::thread::spawn(move ||{
-                sigsegv();
-            }).join().unwrap();
-
-            _handler.simulate_signal(exception_handler::Signal::Segv);
+            handler.simulate_signal(exception_handler::Signal::Segv);
         } else {
             unimplemented!("target is not currently implemented");
         }

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -1,0 +1,103 @@
+const SOCKET_NAME: &str = "minidumper-disk-example";
+
+use minidumper::{Client, Server};
+
+fn main() {
+    if std::env::args().any(|a| a == "--server") {
+        let server = Server::with_name(SOCKET_NAME).expect("failed to create server");
+
+        let ab = std::sync::atomic::AtomicBool::new(false);
+
+        struct Handler;
+
+        impl minidumper::ServerHandler for Handler {
+            /// Called when a crash has been received and a backing file needs to be
+            /// created to store it.
+            fn create_minidump_file(&self) -> Result<std::fs::File, std::io::Error> {
+                let uuid = uuid::Uuid::new_v4();
+
+                std::fs::File::create(format!("dumps/{}.dmp", uuid))
+            }
+
+            /// Called when a crash has been fully written as a minidump to the provided
+            /// file. Also returns the full heap buffer as well.
+            fn on_minidump_created(
+                &self,
+                result: Result<(std::fs::File, Vec<u8>), minidumper::Error>,
+            ) {
+                match result {
+                    Ok((mut file, _)) => {
+                        use std::io::Write;
+                        let _ = file.flush();
+                        log::info!("wrote minidump to disk");
+                    }
+                    Err(e) => {
+                        log::error!("failed to write minidump: {:#}", e);
+                    }
+                }
+            }
+        }
+
+        server
+            .run(Box::new(Handler), &ab)
+            .expect("failed to run server");
+
+        return;
+    }
+
+    //let mut _server_proc = None;
+
+    // Attempt to connect to the server
+    let client = loop {
+        if let Ok(client) = Client::with_name(SOCKET_NAME) {
+            break client;
+        }
+
+        // let exe = std::env::current_exe().expect("unable to find ourselves");
+
+        // _server_proc = Some(
+        //     std::process::Command::new(exe)
+        //         .arg("--server")
+        //         .spawn()
+        //         .expect("unable to spawn server process"),
+        // );
+
+        // // Give it time to start
+        // std::thread::sleep(std::time::Duration::from_millis(100));
+    };
+
+    /// Makes a sad
+    fn sigsev() {
+        let s: &u32 = unsafe {
+            // avoid deref_nullptr lint
+            #[inline]
+            fn get_ptr() -> *const u32 {
+                std::ptr::null()
+            }
+            &*get_ptr()
+        };
+
+        println!("backtrace: {:#?}", backtrace::Backtrace::new());
+        println!("we are crashing by accessing a null reference: {}", *s);
+    }
+
+    // Register our exception handler
+    cfg_if::cfg_if! {
+        if #[cfg(any(target_os = "linux", target_os = "android"))] {
+            let _handler = exception_handler::linux::ExceptionHandler::attach(Box::new(move |crash_context: &exception_handler::linux::CrashContext| {
+                println!("OH NO");
+                let cc: &minidumper::CrashContext = unsafe {
+                    &*(crash_context as *const exception_handler::linux::CrashContext).cast()
+                };
+
+                dbg!(client.request_dump(cc).is_ok())
+            })).expect("failed to attach signal handler");
+
+            std::thread::spawn(move || {
+                sigsev();
+            }).join().unwrap();
+        } else {
+            unimplemented!("target is not currently implemented");
+        }
+    }
+}

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -27,7 +27,7 @@ fn main() {
             fn on_minidump_created(
                 &self,
                 result: Result<minidumper::MinidumpBinary, minidumper::Error>,
-            ) {
+            ) -> bool {
                 match result {
                     Ok(mut md_bin) => {
                         use std::io::Write;
@@ -38,6 +38,8 @@ fn main() {
                         log::error!("failed to write minidump: {:#}", e);
                     }
                 }
+
+                true
             }
 
             fn on_message(&self, kind: u32, buffer: Vec<u8>) {

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -56,7 +56,7 @@ fn main() {
         return;
     }
 
-    //let mut _server_proc = None;
+    let mut _server_proc = None;
 
     // Attempt to connect to the server
     let client = loop {
@@ -82,14 +82,14 @@ fn main() {
         if #[cfg(any(target_os = "linux", target_os = "android"))] {
             client.send_message(std::num::NonZeroU32::new(1).unwrap(), "mistakes will be made").unwrap();
 
-            let _handler = exception_handler::linux::ExceptionHandler::attach(Box::new(move |crash_context: &exception_handler::CrashContext| {
-                log::error!("OH NO");
+            let handler = exception_handler::ExceptionHandler::attach(unsafe {exception_handler::make_crash_event(move |crash_context: &exception_handler::CrashContext| {
+                //log::error!("OH NO");
 
                 // Before we request the crash, send a message to the server
                 client.send_message(std::num::NonZeroU32::new(2).unwrap(), "mistakes were made").unwrap();
 
-                dbg!(client.request_dump(crash_context).is_ok())
-            })).expect("failed to attach signal handler");
+                client.request_dump(crash_context).is_ok()
+            })}).expect("failed to attach signal handler");
 
             handler.simulate_signal(exception_handler::Signal::Segv);
         } else {

--- a/minidumper/src/errors.rs
+++ b/minidumper/src/errors.rs
@@ -8,5 +8,5 @@ pub enum Error {
     UnknownClientPid,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[error(transparent)]
-    Writer(#[from] minidump_writer_linux::errors::WriterError),
+    Writer(#[from] minidump_writer::errors::WriterError),
 }

--- a/minidumper/src/errors.rs
+++ b/minidumper/src/errors.rs
@@ -1,0 +1,12 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("the socket name is invalid")]
+    InvalidName,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("client process requesting crash dump has an unknown or invalid pid")]
+    UnknownClientPid,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[error(transparent)]
+    Writer(#[from] minidump_writer_linux::errors::WriterError),
+}

--- a/minidumper/src/lib.rs
+++ b/minidumper/src/lib.rs
@@ -109,7 +109,10 @@ pub trait ServerHandler: Send + Sync {
     fn create_minidump_file(&self) -> Result<(File, PathBuf), std::io::Error>;
     /// Called when a crash has been fully written as a minidump to the provided
     /// file. Also returns the full heap buffer as well.
-    fn on_minidump_created(&self, result: Result<MinidumpBinary, Error>);
+    ///
+    /// A return value of true indicates that the message loop should exit and
+    /// stop processing messages.
+    fn on_minidump_created(&self, result: Result<MinidumpBinary, Error>) -> bool;
     /// Called when the client sends a message _other_ than a crash event
     fn on_message(&self, kind: u32, buffer: Vec<u8>);
 }

--- a/minidumper/src/lib.rs
+++ b/minidumper/src/lib.rs
@@ -83,6 +83,7 @@
 mod errors;
 
 pub use errors::Error;
+use std::{fs::File, path::PathBuf};
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "android"))] {
@@ -92,12 +93,71 @@ cfg_if::cfg_if! {
     }
 }
 
+pub struct MinidumpBinary {
+    /// The file the minidump was written to, as provided by [`ServerHandler::create_minidump_file`]
+    pub file: File,
+    /// The path to the file as provided by [`ServerHandler::create_minidump_file`].
+    pub path: PathBuf,
+    /// The in-memory contents of the minidump
+    pub contents: Vec<u8>,
+}
+
 /// Allows user code to hook into the server to avoid hardcoding too many details
 pub trait ServerHandler: Send + Sync {
     /// Called when a crash has been received and a backing file needs to be
     /// created to store it.
-    fn create_minidump_file(&self) -> Result<std::fs::File, std::io::Error>;
+    fn create_minidump_file(&self) -> Result<(File, PathBuf), std::io::Error>;
     /// Called when a crash has been fully written as a minidump to the provided
     /// file. Also returns the full heap buffer as well.
-    fn on_minidump_created(&self, result: Result<(std::fs::File, Vec<u8>), Error>);
+    fn on_minidump_created(&self, result: Result<MinidumpBinary, Error>);
+    /// Called when the client sends a message _other_ than a crash event
+    fn on_message(&self, kind: u32, buffer: Vec<u8>);
+}
+
+#[derive(Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq, Debug))]
+#[repr(C)]
+pub(crate) struct Header {
+    kind: u32,
+    size: u32,
+}
+
+impl Header {
+    fn as_bytes(&self) -> &[u8] {
+        #[allow(unsafe_code)]
+        unsafe {
+            let size = std::mem::size_of::<Self>();
+            let ptr = (self as *const Self).cast();
+            std::slice::from_raw_parts(ptr, size)
+        }
+    }
+
+    fn from_bytes(buf: &[u8]) -> Option<Self> {
+        if buf.len() != std::mem::size_of::<Self>() {
+            return None;
+        }
+
+        #[allow(unsafe_code)]
+        unsafe {
+            Some(*buf.as_ptr().cast::<Self>())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Header;
+
+    #[test]
+    fn header_bytes() {
+        let expected = Header {
+            kind: 20,
+            size: 8 * 1024,
+        };
+        let exp_bytes = expected.as_bytes();
+
+        let actual = Header::from_bytes(exp_bytes).unwrap();
+
+        assert_eq!(expected, actual);
+    }
 }

--- a/minidumper/src/lib.rs
+++ b/minidumper/src/lib.rs
@@ -1,0 +1,103 @@
+// BEGIN - Embark standard lints v5 for Rust 1.55+
+// do not change or add/remove here, but one can add exceptions after this section
+// for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+#![deny(unsafe_code)]
+#![warn(
+    clippy::all,
+    clippy::await_holding_lock,
+    clippy::char_lit_as_u8,
+    clippy::checked_conversions,
+    clippy::dbg_macro,
+    clippy::debug_assert_with_mut_call,
+    clippy::disallowed_method,
+    clippy::disallowed_type,
+    clippy::doc_markdown,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::exit,
+    clippy::expl_impl_clone_on_copy,
+    clippy::explicit_deref_methods,
+    clippy::explicit_into_iter_loop,
+    clippy::fallible_impl_from,
+    clippy::filter_map_next,
+    clippy::flat_map_option,
+    clippy::float_cmp_const,
+    clippy::fn_params_excessive_bools,
+    clippy::from_iter_instead_of_collect,
+    clippy::if_let_mutex,
+    clippy::implicit_clone,
+    clippy::imprecise_flops,
+    clippy::inefficient_to_string,
+    clippy::invalid_upcast_comparisons,
+    clippy::large_digit_groups,
+    clippy::large_stack_arrays,
+    clippy::large_types_passed_by_value,
+    clippy::let_unit_value,
+    clippy::linkedlist,
+    clippy::lossy_float_literal,
+    clippy::macro_use_imports,
+    clippy::manual_ok_or,
+    clippy::map_err_ignore,
+    clippy::map_flatten,
+    clippy::map_unwrap_or,
+    clippy::match_on_vec_items,
+    clippy::match_same_arms,
+    clippy::match_wild_err_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::mem_forget,
+    clippy::mismatched_target_os,
+    clippy::missing_enforced_import_renames,
+    clippy::mut_mut,
+    clippy::mutex_integer,
+    clippy::needless_borrow,
+    clippy::needless_continue,
+    clippy::needless_for_each,
+    clippy::option_option,
+    clippy::path_buf_push_overwrite,
+    clippy::ptr_as_ptr,
+    clippy::rc_mutex,
+    clippy::ref_option_ref,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::same_functions_in_if_condition,
+    clippy::semicolon_if_nothing_returned,
+    clippy::single_match_else,
+    clippy::string_add_assign,
+    clippy::string_add,
+    clippy::string_lit_as_bytes,
+    clippy::string_to_string,
+    clippy::todo,
+    clippy::trait_duplication_in_bounds,
+    clippy::unimplemented,
+    clippy::unnested_or_patterns,
+    clippy::unused_self,
+    clippy::useless_transmute,
+    clippy::verbose_file_reads,
+    clippy::zero_sized_map_values,
+    future_incompatible,
+    nonstandard_style,
+    rust_2018_idioms
+)]
+// END - Embark standard lints v0.5 for Rust 1.55+
+// crate-specific exceptions:
+
+mod errors;
+
+pub use errors::Error;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(target_os = "linux", target_os = "android"))] {
+        mod linux;
+
+        pub use linux::{Client, Server, CrashContext};
+    }
+}
+
+/// Allows user code to hook into the server to avoid hardcoding too many details
+pub trait ServerHandler: Send + Sync {
+    /// Called when a crash has been received and a backing file needs to be
+    /// created to store it.
+    fn create_minidump_file(&self) -> Result<std::fs::File, std::io::Error>;
+    /// Called when a crash has been fully written as a minidump to the provided
+    /// file. Also returns the full heap buffer as well.
+    fn on_minidump_created(&self, result: Result<(std::fs::File, Vec<u8>), Error>);
+}

--- a/minidumper/src/linux.rs
+++ b/minidumper/src/linux.rs
@@ -4,4 +4,4 @@ mod server;
 pub use client::Client;
 pub use server::Server;
 
-pub use minidump_writer_linux::crash_context::CrashContext;
+pub use minidump_writer::crash_context::CrashContext;

--- a/minidumper/src/linux.rs
+++ b/minidumper/src/linux.rs
@@ -1,0 +1,7 @@
+mod client;
+mod server;
+
+pub use client::Client;
+pub use server::Server;
+
+pub use minidump_writer_linux::crash_context::CrashContext;

--- a/minidumper/src/linux/client.rs
+++ b/minidumper/src/linux/client.rs
@@ -37,8 +37,10 @@ impl Client {
         let io_bufs = [IoSlice::new(header_buf), IoSlice::new(crash_ctx_buffer)];
         self.socket.send_vectored(&io_bufs)?;
 
+        exception_handler::debug_print!("waiting for dump to finish");
         let mut ack = [0u8; 1];
         self.socket.recv(&mut ack)?;
+        exception_handler::debug_print!("finished!");
 
         Ok(())
     }

--- a/minidumper/src/linux/client.rs
+++ b/minidumper/src/linux/client.rs
@@ -37,10 +37,10 @@ impl Client {
         let io_bufs = [IoSlice::new(header_buf), IoSlice::new(crash_ctx_buffer)];
         self.socket.send_vectored(&io_bufs)?;
 
-        exception_handler::debug_print!("waiting for dump to finish");
+        exception_handler::debug_print!("waiting for dump to finish...");
         let mut ack = [0u8; 1];
         self.socket.recv(&mut ack)?;
-        exception_handler::debug_print!("finished!");
+        exception_handler::debug_print!("minidump creation acked");
 
         Ok(())
     }
@@ -61,6 +61,9 @@ impl Client {
         let io_bufs = [IoSlice::new(header.as_bytes()), IoSlice::new(buffer)];
 
         self.socket.send_vectored(&io_bufs)?;
+
+        let mut ack = [0u8; 1];
+        self.socket.recv(&mut ack)?;
 
         Ok(())
     }

--- a/minidumper/src/linux/client.rs
+++ b/minidumper/src/linux/client.rs
@@ -1,0 +1,43 @@
+use crate::Error;
+
+pub struct Client {
+    socket: uds::UnixSeqpacketConn,
+}
+
+impl Client {
+    /// Creates a new client with the given name.
+    pub fn with_name(name: impl AsRef<str>) -> Result<Self, Error> {
+        let socket_addr =
+            uds::UnixSocketAddr::from_abstract(name.as_ref()).map_err(|_err| Error::InvalidName)?;
+
+        Ok(Self {
+            socket: uds::UnixSeqpacketConn::connect_unix_addr(&socket_addr)?,
+        })
+    }
+
+    /// Requests that the server generate a minidump for the specified crash
+    /// context. This blocks until the server has finished writing the minidump.
+    ///
+    /// This uses a [`exception_handler::linux::CrashContext`] by reference as
+    /// the size of it can be larger than one would want in an alternate stack
+    /// handler, the use of a reference allows the context to be stored outside
+    /// of the stack and heap to avoid that complication, but you may of course
+    /// generate one however you like.
+    pub fn request_dump(&self, crash_context: &super::CrashContext) -> Result<(), Error> {
+        // This is fine since all members of the context are Sized
+        #[allow(unsafe_code)]
+        let buffer = unsafe {
+            std::slice::from_raw_parts(
+                (crash_context as *const super::CrashContext).cast::<u8>(),
+                std::mem::size_of::<super::CrashContext>(),
+            )
+        };
+
+        self.socket.send(buffer)?;
+
+        let mut ack = [0u8; 1];
+        self.socket.recv(&mut ack)?;
+
+        Ok(())
+    }
+}

--- a/minidumper/src/linux/server.rs
+++ b/minidumper/src/linux/server.rs
@@ -1,0 +1,124 @@
+use crate::Error;
+
+use uds::nonblocking::UnixSeqpacketListener;
+
+pub struct Server {
+    socket: UnixSeqpacketListener,
+}
+
+impl Server {
+    /// Creates a new server with the given name.
+    pub fn with_name(name: impl AsRef<str>) -> Result<Self, Error> {
+        let socket_addr =
+            uds::UnixSocketAddr::from_abstract(name.as_ref()).map_err(|_err| Error::InvalidName)?;
+
+        Ok(Self {
+            socket: UnixSeqpacketListener::bind_unix_addr(&socket_addr)?,
+        })
+    }
+
+    /// Runs the server loop, accepting client connections and requests to
+    /// create minidumps
+    pub fn run(
+        &self,
+        handler: Box<dyn crate::ServerHandler>,
+        shutdown: &std::sync::atomic::AtomicBool,
+    ) -> Result<(), Error> {
+        use mio::{Events, Interest, Poll, Token};
+
+        let mut poll = Poll::new()?;
+        let mut events = Events::with_capacity(10);
+        poll.registry()
+            .register(&mut &self.socket, Token(0), Interest::READABLE)?;
+
+        let mut clients = Vec::new();
+        let mut id = 1;
+
+        loop {
+            if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
+                return Ok(());
+            }
+
+            poll.poll(&mut events, None)?;
+
+            for event in events.iter() {
+                if event.token().0 == 0 {
+                    match self.socket.accept_unix_addr() {
+                        Ok((mut accepted, _addr)) => {
+                            let token = Token(id);
+                            id += 1;
+
+                            poll.registry()
+                                .register(&mut accepted, token, Interest::READABLE)?;
+
+                            clients.push((accepted, token));
+                        }
+                        Err(err) => {
+                            println!("failed to accept socket connection: {}", err);
+                        }
+                    }
+                } else {
+                    if let Some(pos) = clients
+                        .iter()
+                        .position(|(_, token)| *token == event.token())
+                    {
+                        let (mut socket, _) = clients.swap_remove(pos);
+
+                        if let Err(err) = Self::handle_crash_request(&socket, handler.as_ref()) {
+                            println!("failed to capture minidump: {}", err);
+                        } else {
+                            println!("captured minidump");
+                        }
+
+                        if let Err(e) = poll.registry().deregister(&mut socket) {
+                            println!("failed to deregister socket: {}", e);
+                        }
+                    }
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
+
+    fn handle_crash_request(
+        socket: &uds::nonblocking::UnixSeqpacketConn,
+        handler: &dyn crate::ServerHandler,
+    ) -> Result<(), Error> {
+        let mut crash_context_buffer = [0u8; std::mem::size_of::<super::CrashContext>()];
+
+        let (len, _all) = socket.recv(&mut crash_context_buffer)?;
+
+        if len != crash_context_buffer.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "client sent an incorrectly sized buffer",
+            )
+            .into());
+        }
+
+        let peer_creds = socket.initial_peer_credentials()?;
+
+        let pid = peer_creds.pid().ok_or_else(|| Error::UnknownClientPid)?;
+
+        #[allow(unsafe_code)]
+        let cc = unsafe { (*crash_context_buffer.as_ptr().cast::<super::CrashContext>()).clone() };
+
+        let mut minidump_file = handler.create_minidump_file()?;
+
+        let mut writer =
+            minidump_writer_linux::minidump_writer::MinidumpWriter::new(pid.get() as i32, cc.tid);
+        writer.set_crash_context(cc);
+
+        let result = writer.dump(&mut minidump_file);
+
+        // Notify the user handler about the minidump, even if we failed to write it
+        handler.on_minidump_created(
+            result
+                .map(|vec| (minidump_file, vec))
+                .map_err(crate::Error::from),
+        );
+
+        Ok(())
+    }
+}

--- a/minidumper/src/linux/server.rs
+++ b/minidumper/src/linux/server.rs
@@ -71,7 +71,7 @@ impl Server {
                 return Ok(());
             }
 
-            poll.poll(&mut events, None)?;
+            poll.poll(&mut events, Some(std::time::Duration::from_millis(10)))?;
 
             for event in events.iter() {
                 if event.token().0 == 0 {
@@ -119,8 +119,6 @@ impl Server {
                     }
                 }
             }
-
-            std::thread::sleep(std::time::Duration::from_millis(1));
         }
     }
 

--- a/sadness-generator/Cargo.toml
+++ b/sadness-generator/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sadness-generator"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[build-dependencies]
+cc = "1.0"

--- a/sadness-generator/build.rs
+++ b/sadness-generator/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let mut build = cc::Build::new();
+
+    build.file("src/sadness.c");
+
+    build.compile("sadness");
+}

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -1,0 +1,54 @@
+#[link(name = "sadness")]
+extern "C" {
+    fn sig_fpe();
+    fn sig_segv();
+    fn sig_ill();
+    fn sig_bus();
+    fn sig_trap();
+}
+
+/// Raises `SIGSABRT` on unix and who knows what on windows
+pub fn raise_abort() {
+    std::process::abort();
+}
+
+/// Raises `SIGSEGV` on unix and a `EXCEPTION_ACCESS_VIOLATION` exception on windows
+pub fn raise_segfault() {
+    unsafe { sig_segv() }
+}
+
+/// Raises `SIGFPE` on unix and a `EXCEPTION_INT_DIVIDE_BY_ZERO` exception on windows
+pub fn raise_floating_point_exception() {
+    unsafe { sig_fpe() }
+}
+
+/// Raises `SIGILL` on unix and a `EXCEPTION_ILLEGAL_INSTRUCTION` exception on windows
+pub fn raise_illegal_instruction() {
+    unsafe { sig_ill() }
+}
+
+/// Raises `SIGBUS` on unix and who knows what on windows
+pub fn raise_bus() {
+    unsafe { sig_bus() }
+}
+
+/// Raises `SIGTRAP` on unix and a `EXCEPTION_BREAKPOINT` exception on windows
+pub fn raise_trap() {
+    unsafe { sig_trap() }
+}
+
+/// Raises `SIGSEGV` on unix and a `EXCEPTION_STACK_OVERFLOW` exception on windows
+pub fn raise_stack_overflow() {
+    std::thread::Builder::new()
+        .name("stackoverflow".to_owned())
+        .stack_size(1024)
+        .spawn(move || {
+            let mut big_boi = [0u8; 2 * 1024];
+            big_boi[big_boi.len() - 1] = 1;
+
+            println!("{:?}", &big_boi[big_boi.len() - 20..]);
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -39,16 +39,8 @@ pub fn raise_trap() {
 
 /// Raises `SIGSEGV` on unix and a `EXCEPTION_STACK_OVERFLOW` exception on windows
 pub fn raise_stack_overflow() {
-    std::thread::Builder::new()
-        .name("stackoverflow".to_owned())
-        .stack_size(1024)
-        .spawn(move || {
-            let mut big_boi = [0u8; 2 * 1024];
-            big_boi[big_boi.len() - 1] = 1;
+    let mut big_boi = [0u8; 4 * 1024 * 1024];
+    big_boi[big_boi.len() - 1] = 1;
 
-            println!("{:?}", &big_boi[big_boi.len() - 20..]);
-        })
-        .unwrap()
-        .join()
-        .unwrap();
+    println!("{:?}", &big_boi[big_boi.len() - 20..]);
 }

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -3,7 +3,7 @@ extern "C" {
     fn sig_fpe();
     fn sig_segv();
     fn sig_ill();
-    fn sig_bus();
+    fn sig_bus(path_ptr: *const u8, path_len: usize);
     fn sig_trap();
 }
 
@@ -28,8 +28,8 @@ pub fn raise_illegal_instruction() {
 }
 
 /// Raises `SIGBUS` on unix and who knows what on windows
-pub fn raise_bus() {
-    unsafe { sig_bus() }
+pub fn raise_bus(path: &str) {
+    unsafe { sig_bus(path.as_ptr(), path.len()) }
 }
 
 /// Raises `SIGTRAP` on unix and a `EXCEPTION_BREAKPOINT` exception on windows
@@ -39,7 +39,7 @@ pub fn raise_trap() {
 
 /// Raises `SIGSEGV` on unix and a `EXCEPTION_STACK_OVERFLOW` exception on windows
 pub fn raise_stack_overflow() {
-    let mut big_boi = [0u8; 4 * 1024 * 1024];
+    let mut big_boi = [0u8; 9 * 1024 * 1024];
     big_boi[big_boi.len() - 1] = 1;
 
     println!("{:?}", &big_boi[big_boi.len() - 20..]);

--- a/sadness-generator/src/sadness.c
+++ b/sadness-generator/src/sadness.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+uint32_t definitely_not_zero() {
+    return 0;
+}
+
+void sig_fpe() {
+    uint32_t ohno = 1 / definitely_not_zero();
+    printf("%u\n", ohno);
+}
+
+void sig_segv() {
+    const uint32_t* oops = NULL;
+    printf("%u\n", *oops);
+}
+
+void sig_ill() {
+    // TODO: x86/_64 only
+    asm("ud2");
+}
+
+// https://en.wikipedia.org/wiki/Bus_error
+void sig_bus() {
+    int *iptr;
+    char *cptr;
+
+    // Enable Alignment Checking on x86_64
+    asm("pushf\norl $0x40000,(%rsp)\npopf");
+
+    // malloc() always provides memory which is aligned for all fundamental types
+    cptr = malloc(sizeof(int) + 1);
+    
+    // Increment the pointer by one, making it misaligned
+    iptr = (int *) ++cptr;
+
+    // Dereference it as an int pointer, causing an unaligned access
+    *iptr = 42;
+}
+
+void sig_trap() {
+    asm("int3");
+}

--- a/sadness-generator/src/sadness.c
+++ b/sadness-generator/src/sadness.c
@@ -1,6 +1,9 @@
+#include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
 
 uint32_t definitely_not_zero() {
     return 0;
@@ -21,22 +24,41 @@ void sig_ill() {
     asm("ud2");
 }
 
-// https://en.wikipedia.org/wiki/Bus_error
-void sig_bus() {
-    int *iptr;
-    char *cptr;
+void sig_bus(const char* path, size_t path_len) {
+    #if 0
+        // https://en.wikipedia.org/wiki/Bus_error
+        int *iptr;
+        char *cptr;
 
-    // Enable Alignment Checking on x86_64
-    asm("pushf\norl $0x40000,(%rsp)\npopf");
+        // This address alignment bus error might actually be a kind we can't
+        // effectively handle, as we need to change processor flags, which
+        // actually affects the entire process, meaning we can crash inside the
+        // signal handler just doing something simple like zeroing memory. This
+        // is probably fine not to handle, at least on x86_64 because it is not
+        // an kind of SIGBUS that should really happen in practice
 
-    // malloc() always provides memory which is aligned for all fundamental types
-    cptr = malloc(sizeof(int) + 1);
-    
-    // Increment the pointer by one, making it misaligned
-    iptr = (int *) ++cptr;
+        // Enable Alignment Checking on x86_64
+        asm("pushf\norl $0x40000,(%rsp)\npopf");
 
-    // Dereference it as an int pointer, causing an unaligned access
-    *iptr = 42;
+        // malloc() always provides memory which is aligned for all fundamental types
+        cptr = malloc(sizeof(int) + 1);
+        
+        // Increment the pointer by one, making it misaligned
+        iptr = (int *) ++cptr;
+
+        // Dereference it as an int pointer, causing an unaligned access
+        *iptr = 42;
+    #else
+        char* fpath = calloc(path_len + 1, 1);
+        strncpy(fpath, path, path_len);
+        int bus_fd = open(fpath, O_RDWR | O_CREAT, 0666);
+        uint8_t* bus_map = mmap(0, 128, PROT_READ | PROT_WRITE, MAP_SHARED, bus_fd, 0);
+
+        printf("%u", bus_map[1]);
+
+        // We won't get here, but it's best to be tidy
+        free(fpath);
+    #endif
 }
 
 void sig_trap() {

--- a/uctx/Cargo.toml
+++ b/uctx/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "uctx"
+description = "libc independent implementation of ucontext"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+cfg-if = "1.0"
+
+[build-dependencies]
+cc = { version = "1.0", features = ["parallel"] }
+
+[dev-dependencies]
+libc = "0.2"

--- a/uctx/build.rs
+++ b/uctx/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("target_os not specified");
+
+    if target_os != "linux" && target_os != "android" {
+        return;
+    }
+
+    let mut build = cc::Build::new();
+
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").expect("target_arch not specified");
+
+    build.include(format!("libunwind/{}", target_arch));
+    build.file(format!("libunwind/{}/getcontext.S", target_arch));
+
+    build.compile("ucontext");
+}

--- a/uctx/libunwind/README.md
+++ b/uctx/libunwind/README.md
@@ -1,0 +1,3 @@
+# libunwind
+
+This directory contains the minimal sources we need from libunwind for (currently) just `getcontext`. The sources change extremely rarely, and it's easier to just copy sources manually than remove all of the sources (which is a majority of them) from the final packaged crate.

--- a/uctx/libunwind/x86_64/getcontext.S
+++ b/uctx/libunwind/x86_64/getcontext.S
@@ -1,0 +1,136 @@
+/* libunwind - a platform-independent unwind library
+   Copyright (C) 2008 Google, Inc
+	Contributed by Paul Pluzhnikov <ppluzhnikov@google.com>
+   Copyright (C) 2010 Konstantin Belousov <kib@freebsd.org>
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "ucontext_i.h"
+
+/*  int getcontext (ucontext_t *ucp)
+
+  Saves the machine context in UCP necessary for libunwind.  
+  Unlike the libc implementation, we don't save the signal mask
+  and hence avoid the cost of a system call per unwind.
+  
+*/
+
+	.global getcontext
+	.type getcontext, @function
+getcontext:
+	.cfi_startproc
+
+	/* Callee saved: RBX, RBP, R12-R15  */
+	movq %r12, UC_MCONTEXT_GREGS_R12(%rdi)
+	movq %r13, UC_MCONTEXT_GREGS_R13(%rdi)
+	movq %r14, UC_MCONTEXT_GREGS_R14(%rdi)
+	movq %r15, UC_MCONTEXT_GREGS_R15(%rdi)
+	movq %rbp, UC_MCONTEXT_GREGS_RBP(%rdi)
+	movq %rbx, UC_MCONTEXT_GREGS_RBX(%rdi)
+
+	/* Save argument registers (not strictly needed, but setcontext 
+	   restores them, so don't restore garbage).  */
+	movq %r8,  UC_MCONTEXT_GREGS_R8(%rdi)
+	movq %r9,  UC_MCONTEXT_GREGS_R9(%rdi)
+	movq %rdi, UC_MCONTEXT_GREGS_RDI(%rdi)
+	movq %rsi, UC_MCONTEXT_GREGS_RSI(%rdi)
+	movq %rdx, UC_MCONTEXT_GREGS_RDX(%rdi)
+	movq %rax, UC_MCONTEXT_GREGS_RAX(%rdi)
+	movq %rcx, UC_MCONTEXT_GREGS_RCX(%rdi)
+
+#if defined __linux__ || defined __sun
+	/* Save fp state (not needed, except for setcontext not
+	   restoring garbage).  */
+	leaq UC_MCONTEXT_FPREGS_MEM(%rdi),%r8
+#ifdef UC_MCONTEXT_FPREGS_PTR
+	movq %r8, UC_MCONTEXT_FPREGS_PTR(%rdi)
+#endif // UC_MCONTEXT_FPREGS_PTR
+	fnstenv (%r8)
+	stmxcsr FPREGS_OFFSET_MXCSR(%r8)
+#elif defined __FreeBSD__
+	fxsave UC_MCONTEXT_FPSTATE(%rdi)
+	movq $UC_MCONTEXT_FPOWNED_FPU,UC_MCONTEXT_OWNEDFP(%rdi)
+	movq $UC_MCONTEXT_FPFMT_XMM,UC_MCONTEXT_FPFORMAT(%rdi)
+	/* Save rflags and segment registers, so that sigreturn(2)
+	does not complain. */
+	pushfq
+	.cfi_adjust_cfa_offset 8
+	popq UC_MCONTEXT_RFLAGS(%rdi)
+	.cfi_adjust_cfa_offset -8
+	movl $0, UC_MCONTEXT_FLAGS(%rdi)
+	movw %cs, UC_MCONTEXT_CS(%rdi)
+	movw %ss, UC_MCONTEXT_SS(%rdi)
+#if 0
+	/* Setting the flags to 0 above disables restore of segment
+	   registers from the context */
+	movw %ds, UC_MCONTEXT_DS(%rdi)
+	movw %es, UC_MCONTEXT_ES(%rdi)
+	movw %fs, UC_MCONTEXT_FS(%rdi)
+	movw %gs, UC_MCONTEXT_GS(%rdi)
+#endif
+	movq $UC_MCONTEXT_MC_LEN_VAL, UC_MCONTEXT_MC_LEN(%rdi)
+#else
+#error Port me
+#endif
+
+	leaq 8(%rsp), %rax /* exclude this call.  */
+	movq %rax, UC_MCONTEXT_GREGS_RSP(%rdi)
+
+	movq 0(%rsp), %rax
+	movq %rax, UC_MCONTEXT_GREGS_RIP(%rdi)
+
+	xorq	%rax, %rax
+	retq
+	.cfi_endproc
+	.size getcontext, . - getcontext
+
+/*  int getcontext_trace (ucontext_t *ucp)
+
+  Saves limited machine context in UCP necessary for libunwind.
+  Unlike getcontext, saves only the parts needed for
+  fast trace. If fast trace fails, caller will have to get the
+  full context.
+*/
+
+	.global getcontext_trace
+	.hidden getcontext_trace
+	.type getcontext_trace, @function
+getcontext_trace:
+	.cfi_startproc
+
+	/* Save only RBP, RBX, RSP, RIP - exclude this call. */
+	movq %rbp, UC_MCONTEXT_GREGS_RBP(%rdi)
+	movq %rbx, UC_MCONTEXT_GREGS_RBX(%rdi)
+
+	leaq 8(%rsp), %rax
+	movq %rax, UC_MCONTEXT_GREGS_RSP(%rdi)
+
+	movq 0(%rsp), %rax
+	movq %rax, UC_MCONTEXT_GREGS_RIP(%rdi)
+
+	xorq	%rax, %rax
+	retq
+	.cfi_endproc
+	.size getcontext_trace, . - getcontext_trace
+
+      /* We do not need executable stack.  */
+      .section        .note.GNU-stack,"",@progbits

--- a/uctx/libunwind/x86_64/ucontext_i.h
+++ b/uctx/libunwind/x86_64/ucontext_i.h
@@ -1,0 +1,101 @@
+/* Copyright (C) 2004 Hewlett-Packard Co.
+     Contributed by David Mosberger-Tang <davidm@hpl.hp.com>.
+
+This file is part of libunwind.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#if defined __linux__
+    #define UC_MCONTEXT_GREGS_R8    0x28
+    #define UC_MCONTEXT_GREGS_R9    0x30
+    #define UC_MCONTEXT_GREGS_R10   0x38
+    #define UC_MCONTEXT_GREGS_R11   0x40
+    #define UC_MCONTEXT_GREGS_R12   0x48
+    #define UC_MCONTEXT_GREGS_R13   0x50
+    #define UC_MCONTEXT_GREGS_R14   0x58
+    #define UC_MCONTEXT_GREGS_R15   0x60
+    #define UC_MCONTEXT_GREGS_RDI   0x68
+    #define UC_MCONTEXT_GREGS_RSI   0x70
+    #define UC_MCONTEXT_GREGS_RBP   0x78
+    #define UC_MCONTEXT_GREGS_RBX   0x80
+    #define UC_MCONTEXT_GREGS_RDX   0x88
+    #define UC_MCONTEXT_GREGS_RAX   0x90
+    #define UC_MCONTEXT_GREGS_RCX   0x98
+    #define UC_MCONTEXT_GREGS_RSP   0xa0
+    #define UC_MCONTEXT_GREGS_RIP   0xa8
+    #define UC_MCONTEXT_FPREGS_PTR  0x1a8
+    #define UC_MCONTEXT_FPREGS_MEM  0xe0
+    #define UC_SIGMASK              0x128
+    #define FPREGS_OFFSET_MXCSR     0x18
+#elif defined __FreeBSD__
+    #define UC_SIGMASK              0x0
+    #define UC_MCONTEXT_GREGS_RDI   0x18
+    #define UC_MCONTEXT_GREGS_RSI   0x20
+    #define UC_MCONTEXT_GREGS_RDX   0x28
+    #define UC_MCONTEXT_GREGS_RCX   0x30
+    #define UC_MCONTEXT_GREGS_R8    0x38
+    #define UC_MCONTEXT_GREGS_R9    0x40
+    #define UC_MCONTEXT_GREGS_RAX   0x48
+    #define UC_MCONTEXT_GREGS_RBX   0x50
+    #define UC_MCONTEXT_GREGS_RBP   0x58
+    #define UC_MCONTEXT_GREGS_R10   0x60
+    #define UC_MCONTEXT_GREGS_R11   0x68
+    #define UC_MCONTEXT_GREGS_R12   0x70
+    #define UC_MCONTEXT_GREGS_R13   0x78
+    #define UC_MCONTEXT_GREGS_R14   0x80
+    #define UC_MCONTEXT_GREGS_R15   0x88
+    #define UC_MCONTEXT_FS          0x94
+    #define UC_MCONTEXT_GS          0x96
+    #define UC_MCONTEXT_FLAGS       0xa0
+    #define UC_MCONTEXT_ES          0xa4
+    #define UC_MCONTEXT_DS          0xa6
+    #define UC_MCONTEXT_GREGS_RIP   0xb0
+    #define UC_MCONTEXT_CS          0xb8
+    #define UC_MCONTEXT_RFLAGS      0xc0
+    #define UC_MCONTEXT_GREGS_RSP   0xc8
+    #define UC_MCONTEXT_SS          0xd0
+    #define UC_MCONTEXT_MC_LEN      0xd8
+    #define UC_MCONTEXT_FPFORMAT    0xe0
+    #define UC_MCONTEXT_OWNEDFP     0xe8
+    #define UC_MCONTEXT_FPSTATE     0xf0
+    #define UC_MCONTEXT_FPOWNED_FPU 0x20001
+    #define UC_MCONTEXT_FPFMT_XMM   0x10002
+    #define UC_MCONTEXT_MC_LEN_VAL  0x320
+#elif defined __sun
+    #define UC_MCONTEXT_GREGS_R8	0x78
+    #define UC_MCONTEXT_GREGS_R9	0x70
+    #define UC_MCONTEXT_GREGS_R10	0x68
+    #define UC_MCONTEXT_GREGS_R11	0x60
+    #define UC_MCONTEXT_GREGS_R12	0x58
+    #define UC_MCONTEXT_GREGS_R13	0x50
+    #define UC_MCONTEXT_GREGS_R14	0x48
+    #define UC_MCONTEXT_GREGS_R15	0x40
+    #define UC_MCONTEXT_GREGS_RDI	0x80
+    #define UC_MCONTEXT_GREGS_RSI	0x88
+    #define UC_MCONTEXT_GREGS_RBP	0x90
+    #define UC_MCONTEXT_GREGS_RBX	0x98
+    #define UC_MCONTEXT_GREGS_RDX	0xa0
+    #define UC_MCONTEXT_GREGS_RAX	0xb0
+    #define UC_MCONTEXT_GREGS_RCX	0xa8
+    #define UC_MCONTEXT_GREGS_RSP	0xe0
+    #define UC_MCONTEXT_GREGS_RIP	0xc8
+    #define UC_MCONTEXT_FPREGS_MEM	0x120
+    #define FPREGS_OFFSET_MXCSR	0x18
+#endif

--- a/uctx/src/lib.rs
+++ b/uctx/src/lib.rs
@@ -1,0 +1,178 @@
+// BEGIN - Embark standard lints v5 for Rust 1.55+
+// do not change or add/remove here, but one can add exceptions after this section
+// for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+#![deny(unsafe_code)]
+#![warn(
+    clippy::all,
+    clippy::await_holding_lock,
+    clippy::char_lit_as_u8,
+    clippy::checked_conversions,
+    clippy::dbg_macro,
+    clippy::debug_assert_with_mut_call,
+    clippy::disallowed_method,
+    clippy::disallowed_type,
+    clippy::doc_markdown,
+    clippy::empty_enum,
+    clippy::enum_glob_use,
+    clippy::exit,
+    clippy::expl_impl_clone_on_copy,
+    clippy::explicit_deref_methods,
+    clippy::explicit_into_iter_loop,
+    clippy::fallible_impl_from,
+    clippy::filter_map_next,
+    clippy::flat_map_option,
+    clippy::float_cmp_const,
+    clippy::fn_params_excessive_bools,
+    clippy::from_iter_instead_of_collect,
+    clippy::if_let_mutex,
+    clippy::implicit_clone,
+    clippy::imprecise_flops,
+    clippy::inefficient_to_string,
+    clippy::invalid_upcast_comparisons,
+    clippy::large_digit_groups,
+    clippy::large_stack_arrays,
+    clippy::large_types_passed_by_value,
+    clippy::let_unit_value,
+    clippy::linkedlist,
+    clippy::lossy_float_literal,
+    clippy::macro_use_imports,
+    clippy::manual_ok_or,
+    clippy::map_err_ignore,
+    clippy::map_flatten,
+    clippy::map_unwrap_or,
+    clippy::match_on_vec_items,
+    clippy::match_same_arms,
+    clippy::match_wild_err_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::mem_forget,
+    clippy::mismatched_target_os,
+    clippy::missing_enforced_import_renames,
+    clippy::mut_mut,
+    clippy::mutex_integer,
+    clippy::needless_borrow,
+    clippy::needless_continue,
+    clippy::needless_for_each,
+    clippy::option_option,
+    clippy::path_buf_push_overwrite,
+    clippy::ptr_as_ptr,
+    clippy::rc_mutex,
+    clippy::ref_option_ref,
+    clippy::rest_pat_in_fully_bound_structs,
+    clippy::same_functions_in_if_condition,
+    clippy::semicolon_if_nothing_returned,
+    clippy::single_match_else,
+    clippy::string_add_assign,
+    clippy::string_add,
+    clippy::string_lit_as_bytes,
+    clippy::string_to_string,
+    clippy::todo,
+    clippy::trait_duplication_in_bounds,
+    clippy::unimplemented,
+    clippy::unnested_or_patterns,
+    clippy::unused_self,
+    clippy::useless_transmute,
+    clippy::verbose_file_reads,
+    clippy::zero_sized_map_values,
+    future_incompatible,
+    nonstandard_style,
+    rust_2018_idioms
+)]
+// END - Embark standard lints v0.5 for Rust 1.55+
+// crate-specific exceptions:
+#![allow(unsafe_code, nonstandard_style)]
+
+use std::ffi::c_void;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(
+        target_os = "linux",
+        target_os = "l4re",
+        target_os = "android",
+        target_os = "emscripten"))
+    ] {
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        pub struct sigset_t {
+            #[cfg(target_pointer_width = "32")]
+            __val: [u32; 32],
+            #[cfg(target_pointer_width = "64")]
+            __val: [u64; 16],
+        }
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        pub struct ucontext_t {
+            pub uc_flags: u64,
+            pub uc_link: *mut ucontext_t,
+            pub uc_stack: stack_t,
+            pub uc_mcontext: mcontext_t,
+            pub uc_sigmask: sigset_t,
+            __private: [u8; 512],
+        }
+
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        pub struct stack_t {
+            pub ss_sp: *mut c_void,
+            pub ss_flags: i32,
+            pub ss_size: usize,
+        }
+
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        pub struct mcontext_t {
+            pub gregs: [i64; 23],
+            pub fpregs: *mut fpregset_t,
+            __reserved: [u64; 8],
+        }
+
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        pub struct fpregset_t {
+            pub cwd: u16,
+            pub swd: u16,
+            pub ftw: u16,
+            pub fop: u16,
+            pub rip: u64,
+            pub rdp: u64,
+            pub mxcsr: u32,
+            pub mxcr_mask: u32,
+            pub st_space: [u32; 32],
+            pub xmm_space: [u32; 64],
+            __padding: [u64; 12],
+        }
+    }
+}
+
+#[link(name = "ucontext")]
+extern "C" {
+    pub fn getcontext(ctx: *mut ucontext_t) -> i32;
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn gets_context() {
+        unsafe {
+            let mut uctx = std::mem::zeroed();
+
+            assert_eq!(super::getcontext(&mut uctx), 0);
+
+            assert!(!uctx.uc_mcontext.fpregs.is_null());
+        }
+    }
+
+    // Musl doesn't contain fpregs in libc because reasons https://github.com/rust-lang/libc/pull/1646
+    #[cfg(not(target_env = "musl"))]
+    #[test]
+    fn matches_libc() {
+        assert_eq!(
+            std::mem::size_of::<libc::ucontext_t>(),
+            std::mem::size_of::<super::ucontext_t>()
+        );
+    }
+}


### PR DESCRIPTION
This is a first pass implementation of the core components in this repository. This pass only addresses `x86_64-linux` targets at the moment since that was easiest to test.

- `exception-handler` - Heavily based off of breakpad's linux signal handler, this wraps up all of the gnarly signal handling code and calls a user provided callback with the signal details
- `uctx` - Unix signal handlers use a `ucontext_t` as part of the signal info to relay state about place and state of the thread where a signal was raised. Unfortunately this was deprecated in POSIX...but there is no replacement AFAIK. This is a problem since libc doesn't support ucontext_t fully for musl, because it's deprecated, but when using the ucontext_t to get information for crash dumps, several fields need to be accessed that aren't present in the libc version, so instead of try and get this working (and stay working) I just made our own small version based off of libunwind, as the structure is really just arch specific, and we need to be able to pass it from an initial signal handler all the way to a crash dumper
- `minidumper` - This implements a simple IPC client/server where the client is meant to be run in a process that wants to monitor for crashes, and the server, which is responsible for handling minidump requests from the client and creating a minidump similar to how breakpad works. The linux implementation for the crash dump creation was already implemented in https://github.com/msirringhaus/minidump_writer_linux, thus just uses a fork that changes it to use the crash context from the exception handler so that we don't have any messy unsafe or bit twiddling shenanigans

There are also 2 crates purely for exercising these other implementation crates. I'm rather proud of the naming for `sadness-generator`.