### PR TITLE
Improve MacOS support

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,14 +14,17 @@ name: CI
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2022, macos-11]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.59.0"
+          toolchain: "1.60.0"
           override: true
 
       # make sure all code has been formatted with rustfmt

--- a/crash-context/src/linux.rs
+++ b/crash-context/src/linux.rs
@@ -82,7 +82,7 @@ cfg_if::cfg_if! {
         #[doc(hidden)]
         pub struct ucontext_t {
             pub uc_flags: u64,
-            pub uc_link: *mut ucontext_t,
+            uc_link: *mut ucontext_t,
             pub uc_stack: stack_t,
             pub uc_mcontext: mcontext_t,
             pub uc_sigmask: sigset_t,
@@ -120,7 +120,7 @@ cfg_if::cfg_if! {
         #[doc(hidden)]
         pub struct ucontext_t {
             pub uc_flags: u32,
-            pub uc_link: *mut ucontext_t,
+            uc_link: *mut ucontext_t,
             pub uc_stack: stack_t,
             pub uc_mcontext: mcontext_t,
             pub uc_sigmask: sigset_t,
@@ -165,7 +165,7 @@ cfg_if::cfg_if! {
         #[doc(hidden)]
         pub struct ucontext_t {
             pub uc_flags: u64,
-            pub uc_link: *mut ucontext_t,
+            uc_link: *mut ucontext_t,
             pub uc_stack: stack_t,
             pub uc_sigmask: sigset_t,
             pub uc_mcontext: mcontext_t,
@@ -221,7 +221,7 @@ cfg_if::cfg_if! {
         #[doc(hidden)]
         pub struct ucontext_t {
             pub uc_flags: u32,
-            pub uc_link: *mut ucontext_t,
+            uc_link: *mut ucontext_t,
             pub uc_stack: stack_t,
             // Note that the mcontext_t and sigset_t are swapped compared to
             // all of the other arches currently supported :p

--- a/crash-context/src/mac.rs
+++ b/crash-context/src/mac.rs
@@ -1,7 +1,9 @@
+pub mod ipc;
+
 use mach2::{exception_types as et, mach_types as mt};
 
 /// Information on the exception that caused the crash
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct ExceptionInfo {
     /// The exception kind
     pub kind: et::exception_type_t,
@@ -12,6 +14,7 @@ pub struct ExceptionInfo {
 }
 
 /// Full Macos crash context
+#[derive(Debug)]
 pub struct CrashContext {
     /// The process which crashed
     pub task: mt::task_t,

--- a/crash-context/src/mac/ipc.rs
+++ b/crash-context/src/mac/ipc.rs
@@ -1,0 +1,495 @@
+//! Unfortunately, sending a [`CrashContext`] to another process on Macos
+//! needs to be done via mach ports, as, for example, `mach_task_self` is a
+//! special handle that needs to be translated into the "actual" task when used
+//! by another process, this _might_ be possible completely in userspace, but
+//! examining the source code for this leads me to believe that there are enough
+//! footguns, particularly around security, that this might take a while, so for
+//! now, if you need to use a [`CrashContext`] across processes, you need
+//! to use the IPC mechanisms here to get meaningful/accurate data
+//!
+//! Note that in all cases of an optional timeout, a `None` will return
+//! immediately regardless of whether the messaged has been enqueued or
+//! dequeued from the kernel queue, so it is _highly_ recommended to use
+//! reasonable timeouts for sending and receiving messages between processes.
+
+use crate::CrashContext;
+use mach2::{
+    bootstrap, kern_return::KERN_SUCCESS, mach_port, message as msg, port, task,
+    traps::mach_task_self,
+};
+pub use mach2::{kern_return::kern_return_t, message::mach_msg_return_t};
+use std::{ffi::CStr, time::Duration};
+
+extern "C" {
+    /// From <usr/include/mach/mach_traps.h>, there is no binding for this in mach2
+    pub fn pid_for_task(task: port::mach_port_name_t, pid: *mut i32) -> kern_return_t;
+}
+
+/// The actual crash context message sent and received. This message is a single
+/// struct since it needs to be contiguous block of memory. I suppose it's like
+/// this because people are expected to use MIG to generate the interface code,
+/// but it's ugly as hell regardless.
+#[repr(C)]
+#[derive(Debug)]
+struct CrashContextMessage {
+    head: msg::mach_msg_header_t,
+    /// When providing port descriptors, this must be present to say how many
+    /// of them follow the header and body
+    body: msg::mach_msg_body_t,
+    // These are the really the critical piece of the payload, during
+    // sending (or receiving?) these are turned into descriptors that
+    // can actually be used by another process
+    /// The task that crashed (ie `mach_task_self`)
+    task: msg::mach_msg_port_descriptor_t,
+    /// The thread that crashed
+    crash_thread: msg::mach_msg_port_descriptor_t,
+    /// The handler thread, probably, but not necessarily `mach_thread_self`
+    handler_thread: msg::mach_msg_port_descriptor_t,
+    // Port opened by the client to receive an ack from the server
+    ack_port: msg::mach_msg_port_descriptor_t,
+    /// Combination of the FLAG_* constants
+    flags: u32,
+    /// The exception type
+    exception_kind: i32,
+    /// The exception code
+    exception_code: i64,
+    /// The optional exception subcode
+    exception_subcode: i64,
+}
+
+const FLAG_HAS_EXCEPTION: u32 = 0x1;
+const FLAG_HAS_SUBCODE: u32 = 0x2;
+
+/// Message sent from the [`Receiver`] upon receiving and handling a [`CrashContextMessage`]
+#[repr(C)]
+struct AcknowledgementMessage {
+    head: msg::mach_msg_header_t,
+    result: u32,
+}
+
+/// An error that can occur while interacting with mach ports
+#[derive(Copy, Clone, Debug)]
+pub enum Error {
+    /// A kernel error will generally indicate an error occurred while creating
+    /// or modifying a mach port
+    Kernel(kern_return_t),
+    /// A message error indicates an error occurred while sending or receiving
+    /// a message on a mach port
+    Message(mach_msg_return_t),
+}
+
+impl std::error::Error for Error {}
+
+use std::fmt;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: use a good string for the error codes
+        write!(f, "{:?}", self)
+    }
+}
+
+macro_rules! kern {
+    ($call:expr) => {{
+        let res = $call;
+
+        if res != KERN_SUCCESS {
+            return Err(Error::Kernel(res));
+        }
+    }};
+}
+
+macro_rules! msg {
+    ($call:expr) => {{
+        let res = $call;
+
+        if res != msg::MACH_MSG_SUCCESS {
+            return Err(Error::Message(res));
+        }
+    }};
+}
+
+/// Sends a [`CrashContext`] from a crashing process to another process running
+/// a [`Server`] with the same name
+pub struct Client {
+    port: port::mach_port_t,
+}
+
+impl Client {
+    /// Attempts to create a new client that can send messages to a [`Server`]
+    /// that was created with the specified name.
+    ///
+    /// # Errors
+    ///
+    /// The specified port is not available for some reason, if you expect the
+    /// port to be created you can retry this function until it connects.
+    pub fn create(name: &CStr) -> Result<Self, Error> {
+        // SAFETY: syscalls. The user has no invariants to uphold, hence the
+        // unsafe not being on the function as a whole
+        unsafe {
+            let mut task_bootstrap_port = 0;
+            kern!(task::task_get_special_port(
+                mach_task_self(),
+                task::TASK_BOOTSTRAP_PORT,
+                &mut task_bootstrap_port
+            ));
+
+            let mut port = 0;
+            kern!(bootstrap::bootstrap_look_up(
+                task_bootstrap_port,
+                name.as_ptr(),
+                &mut port
+            ));
+
+            Ok(Self { port })
+        }
+    }
+
+    /// Sends the specified [`CrateContext`] to a [`Server`].
+    ///
+    /// If the ack from the [`Server`] times out `Ok(None)` is returned, otherwise
+    /// it is the value specified in the [`Server`] process to [`Acknowledger::send_ack`]
+    pub fn send_crash_context(
+        &self,
+        ctx: &CrashContext,
+        send_timeout: Option<Duration>,
+        receive_timeout: Option<Duration>,
+    ) -> Result<Option<u32>, Error> {
+        // SAFETY: syscalls. Again, the user has no invariants to uphold, so
+        // the function itself is not marked unsafe
+        unsafe {
+            // Create a new port to receive a response from the reciving end of
+            // this port so we that we know when it has actually processed the
+            // CrashContext, which is (presumably) interesting for the caller. If
+            // that is not interesting they can set the receive_timeout to 0 to
+            // just return immediately
+            let mut ack_port = AckReceiver::new()?;
+
+            let (flags, exception_kind, exception_code, exception_subcode) =
+                if let Some(exc) = ctx.exception {
+                    (
+                        FLAG_HAS_EXCEPTION
+                            | if exc.subcode.is_some() {
+                                FLAG_HAS_SUBCODE
+                            } else {
+                                0
+                            },
+                        exc.kind,
+                        exc.code,
+                        exc.subcode.unwrap_or_default(),
+                    )
+                } else {
+                    (0, 0, 0, 0)
+                };
+
+            let mut msg = CrashContextMessage {
+                head: msg::mach_msg_header_t {
+                    msgh_bits: msg::MACH_MSG_TYPE_COPY_SEND | msg::MACH_MSGH_BITS_COMPLEX,
+                    msgh_size: std::mem::size_of::<CrashContextMessage>() as u32,
+                    msgh_remote_port: self.port,
+                    msgh_local_port: port::MACH_PORT_NULL,
+                    msgh_voucher_port: port::MACH_PORT_NULL,
+                    msgh_id: 0,
+                },
+                body: msg::mach_msg_body_t {
+                    msgh_descriptor_count: 4,
+                },
+                task: msg::mach_msg_port_descriptor_t::new(ctx.task, msg::MACH_MSG_TYPE_COPY_SEND),
+                crash_thread: msg::mach_msg_port_descriptor_t::new(
+                    ctx.thread,
+                    msg::MACH_MSG_TYPE_COPY_SEND,
+                ),
+                handler_thread: msg::mach_msg_port_descriptor_t::new(
+                    ctx.handler_thread,
+                    msg::MACH_MSG_TYPE_COPY_SEND,
+                ),
+                ack_port: msg::mach_msg_port_descriptor_t::new(
+                    ack_port.port,
+                    msg::MACH_MSG_TYPE_COPY_SEND,
+                ),
+                flags,
+                exception_kind,
+                exception_code,
+                exception_subcode,
+            };
+
+            // Try to actually send the message to the Server
+            msg!(msg::mach_msg(
+                &mut msg.head,
+                msg::MACH_SEND_MSG | msg::MACH_SEND_TIMEOUT,
+                msg.head.msgh_size,
+                0,
+                port::MACH_PORT_NULL,
+                send_timeout
+                    .map(|st| st.as_millis() as u32)
+                    .unwrap_or_default(),
+                port::MACH_PORT_NULL
+            ));
+
+            // Wait for a response from the Server
+            match ack_port.recv_ack(receive_timeout) {
+                Ok(result) => Ok(Some(result)),
+                Err(Error::Message(msg::MACH_RCV_TIMED_OUT)) => Ok(None),
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+
+/// Returned from [`Server::try_recv_crash_context`] when a [`Client`] has sent
+/// a crash context
+pub struct ReceivedCrashContext {
+    /// The crash context sent by a [`Client`]
+    pub crash_context: CrashContext,
+    /// Allows the sending of an ack back to the [`Client`] to acknowledge that
+    /// your code has received and processed the [`CrashContext`]
+    pub acker: Acknowledger,
+    /// The process id of the process the [`Client`] lives in. This is retrieved
+    /// via `pid_for_task`.
+    pub pid: u32,
+}
+
+/// Receives a [`CrashContext`] from another process
+pub struct Server {
+    port: port::mach_port_t,
+}
+
+impl Server {
+    /// Creates a new [`Server`] "bound" to the specified service name.
+    pub fn create(name: &CStr) -> Result<Self, Error> {
+        // SAFETY: syscalls. Again, the caller has no invariants to uphold, so
+        // the entire function is not marked as unsafe
+        unsafe {
+            let mut task_bootstrap_port = 0;
+            kern!(task::task_get_special_port(
+                mach_task_self(),
+                task::TASK_BOOTSTRAP_PORT,
+                &mut task_bootstrap_port
+            ));
+
+            let mut port = 0;
+            // Note that Breakpad uses bootstrap_register instead of this function as
+            // MacOS 10.5 apparently deprecated bootstrap_register and then provided
+            // bootstrap_check_in, but broken. However, 10.5 had its most recent update
+            // over 13 years ago, and is not supported by Apple, so why should we?
+            kern!(bootstrap::bootstrap_check_in(
+                task_bootstrap_port,
+                name.as_ptr(),
+                &mut port,
+            ));
+
+            Ok(Self { port })
+        }
+    }
+
+    /// Attempts to retrieve a [`CrashContext`] sent from a crashing process.
+    ///
+    /// Note that in event of a timeout, this method will return `Ok(None)` to
+    /// indicate that a crash context was unavailable rather than an error.
+    pub fn try_recv_crash_context(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> Result<Option<ReceivedCrashContext>, Error> {
+        // SAFETY: syscalls. The caller has no invariants to uphold, so the
+        // entire function is not marked unsafe.
+        unsafe {
+            let mut crash_ctx_msg: CrashContextMessage = std::mem::zeroed();
+            crash_ctx_msg.head.msgh_local_port = self.port;
+
+            let ret = msg::mach_msg(
+                &mut crash_ctx_msg.head,
+                msg::MACH_RCV_MSG | msg::MACH_RCV_TIMEOUT,
+                0,
+                // So you may be thinking, wow, you are lying to the kernel about
+                // the size of the buffer it can fill, this is terrible and you
+                // should be ashamed, however, if we don't lie here, mach_msg will
+                // return `MACH_RCV_TOO_LARGE`. I _think_ this might be because
+                // the data payload that follows the header, body, and descriptors
+                // needs to be 4-byte aligned or something? But regardless, if
+                // we lie, the kernel only fills out the actual size of the message,
+                // which is the real size of this struct and everything is happy.
+                // Except me, because this is the kind of stuff that should be
+                // documented, and the documentation that does exist (ie, not Apple's)
+                // makes no mention of this, at least that I have found so far,
+                // but of course, since there is no single source of truth the
+                // "documentation" for this stuff is spread across random blog
+                // posts and GNU documentation that probably comes from the 90s.
+                // NOT SALTY AT ALL
+                std::mem::size_of::<CrashContextMessage>() as u32 + 8,
+                self.port,
+                timeout.map(|t| t.as_millis() as u32).unwrap_or_default(),
+                port::MACH_PORT_NULL,
+            );
+
+            if ret == msg::MACH_RCV_TIMED_OUT {
+                return Ok(None);
+            } else if ret != msg::MACH_MSG_SUCCESS {
+                return Err(Error::Message(ret));
+            }
+
+            // Reconstruct a crash context from the message we received
+            let exception = if crash_ctx_msg.flags & FLAG_HAS_EXCEPTION != 0 {
+                Some(crate::ExceptionInfo {
+                    kind: crash_ctx_msg.exception_kind,
+                    code: crash_ctx_msg.exception_code,
+                    subcode: (crash_ctx_msg.flags & FLAG_HAS_SUBCODE != 0)
+                        .then(|| crash_ctx_msg.exception_subcode),
+                })
+            } else {
+                None
+            };
+
+            let crash_context = CrashContext {
+                task: crash_ctx_msg.task.name,
+                thread: crash_ctx_msg.crash_thread.name,
+                handler_thread: crash_ctx_msg.handler_thread.name,
+                exception,
+            };
+
+            // Translate the task to a pid so the user doesn't have to do it
+            // since there is not a binding available in libc/mach/mach2 for it
+            let mut pid = 0;
+            kern!(pid_for_task(crash_ctx_msg.task.name, &mut pid));
+            let ack_port = crash_ctx_msg.ack_port.name;
+
+            // Provide a way for the user to tell the client when they are done
+            // processing the crash context, unless the specified port was not
+            // set or somehow died immediately
+            let acker = Acknowledger {
+                port: (ack_port != port::MACH_PORT_DEAD && ack_port != port::MACH_PORT_NULL)
+                    .then(|| ack_port),
+            };
+
+            Ok(Some(ReceivedCrashContext {
+                crash_context,
+                acker,
+                pid: pid as u32,
+            }))
+        }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        // SAFETY: syscall
+        unsafe {
+            mach_port::mach_port_deallocate(mach_task_self(), self.port);
+        }
+    }
+}
+
+/// Used by a process running the [`Server`] to send a response back to the
+/// [`Client`] that sent a [`CrashContext`] after it has finished
+/// processing.
+pub struct Acknowledger {
+    port: Option<port::mach_port_t>,
+}
+
+impl Acknowledger {
+    /// Sends an ack back to the client that sent a [`CrashContext`]
+    pub fn send_ack(&mut self, ack: u32, timeout: Option<Duration>) -> Result<(), Error> {
+        if let Some(port) = self.port {
+            // SAFETY: syscalls. The caller has no invariants to uphold, so the
+            // entire function is not marked unsafe.
+            unsafe {
+                let mut msg = AcknowledgementMessage {
+                    head: msg::mach_msg_header_t {
+                        msgh_bits: msg::MACH_MSG_TYPE_COPY_SEND,
+                        msgh_size: std::mem::size_of::<AcknowledgementMessage>() as u32,
+                        msgh_remote_port: port,
+                        msgh_local_port: port::MACH_PORT_NULL,
+                        msgh_voucher_port: port::MACH_PORT_NULL,
+                        msgh_id: 0,
+                    },
+                    result: ack,
+                };
+
+                // Try to actually send the message
+                msg!(msg::mach_msg(
+                    &mut msg.head,
+                    msg::MACH_SEND_MSG | msg::MACH_SEND_TIMEOUT,
+                    msg.head.msgh_size,
+                    0,
+                    port::MACH_PORT_NULL,
+                    timeout.map(|t| t.as_millis() as u32).unwrap_or_default(),
+                    port::MACH_PORT_NULL
+                ));
+
+                Ok(())
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Used by [`Sender::send_crash_context`] to create a port to receive the
+/// external process's response to sending a [`CrashContext`]
+struct AckReceiver {
+    port: port::mach_port_t,
+}
+
+impl AckReceiver {
+    /// Allocates a new port to receive an ack from a [`Server`]
+    ///
+    /// SAFETY: syscalls. Only used internally hence the entire function being
+    /// marked unsafe.
+    unsafe fn new() -> Result<Self, Error> {
+        let mut port = 0;
+        kern!(mach_port::mach_port_allocate(
+            mach_task_self(),
+            port::MACH_PORT_RIGHT_RECEIVE,
+            &mut port
+        ));
+
+        kern!(mach_port::mach_port_insert_right(
+            mach_task_self(),
+            port,
+            port,
+            msg::MACH_MSG_TYPE_MAKE_SEND
+        ));
+
+        Ok(Self { port })
+    }
+
+    /// Waits for the specified duration to receive a result from the [`Server`]
+    /// that was sent a [`CrashContext`]
+    ///
+    /// SAFETY: syscalls. Only used internally hence the entire function being
+    /// marked unsafe.
+    unsafe fn recv_ack(&mut self, timeout: Option<Duration>) -> Result<u32, Error> {
+        let mut ack = AcknowledgementMessage {
+            head: msg::mach_msg_header_t {
+                msgh_bits: 0,
+                msgh_size: std::mem::size_of::<AcknowledgementMessage>() as u32,
+                msgh_remote_port: port::MACH_PORT_NULL,
+                msgh_local_port: self.port,
+                msgh_voucher_port: port::MACH_PORT_NULL,
+                msgh_id: 0,
+            },
+            result: 0,
+        };
+
+        // Wait for a response from the Server
+        msg!(msg::mach_msg(
+            &mut ack.head,
+            msg::MACH_RCV_MSG | msg::MACH_RCV_TIMEOUT,
+            0,
+            ack.head.msgh_size,
+            self.port,
+            timeout.map(|t| t.as_millis() as u32).unwrap_or_default(),
+            port::MACH_PORT_NULL
+        ));
+
+        Ok(ack.result)
+    }
+}
+
+impl Drop for AckReceiver {
+    fn drop(&mut self) {
+        // SAFETY: syscall
+        unsafe {
+            mach_port::mach_port_deallocate(mach_task_self(), self.port);
+        }
+    }
+}

--- a/crash-context/src/windows.rs
+++ b/crash-context/src/windows.rs
@@ -9,6 +9,8 @@ pub struct CrashContext {
     /// so that external processes don't need to use `ReadProcessMemory` to inspect
     /// the exception code
     pub exception_code: i32,
+    /// The pid of the process that crashed
+    pub process_id: u32,
     /// The thread id on which the exception occurred
     pub thread_id: u32,
 }

--- a/crash-handler/src/error.rs
+++ b/crash-handler/src/error.rs
@@ -1,20 +1,20 @@
 use std::fmt;
 
+/// An error that can occur when attaching or detaching a [`crate::CrashHandler`]
 #[derive(Debug)]
 pub enum Error {
+    /// Unable to `mmap` memory
     OutOfMemory,
-    InvalidArgs,
-    Format(std::fmt::Error),
-    /// For simplicity sake, only one `ExceptionHandler` can be registered
+    /// For simplicity sake, only one [`crate::CrashHandler`] can be registered
     /// at any one time.
     HandlerAlreadyInstalled,
+    /// An I/O or other syscall failed
     Io(std::io::Error),
 }
 
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Format(inner) => Some(inner),
             Self::Io(inner) => Some(inner),
             _ => None,
         }
@@ -25,19 +25,11 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::OutOfMemory => f.write_str("unable to allocate memory"),
-            Self::InvalidArgs => f.write_str("invalid arguments provided"),
-            Self::Format(e) => write!(f, "{}", e),
             Self::HandlerAlreadyInstalled => {
                 f.write_str("an exception handler is already installed")
             }
             Self::Io(e) => write!(f, "{}", e),
         }
-    }
-}
-
-impl From<std::fmt::Error> for Error {
-    fn from(e: std::fmt::Error) -> Self {
-        Self::Format(e)
     }
 }
 

--- a/crash-handler/src/linux/state.rs
+++ b/crash-handler/src/linux/state.rs
@@ -439,6 +439,7 @@ impl HandlerInner {
                 }
             }
 
+            cc.pid = std::process::id() as i32;
             cc.tid = libc::syscall(libc::SYS_gettid) as i32;
         }
 

--- a/crash-handler/src/mac/ffi.rs
+++ b/crash-handler/src/mac/ffi.rs
@@ -36,9 +36,6 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Synonomous with `MACH_MSG_TYPE_MOVE_SEND`
-pub const MACH_MSG_TYPE_PORT_SEND: u8 = msg::MACH_MSG_TYPE_MOVE_SEND as u8; // 17
-
 // /// Machine-independent exception behaviors. Possible values for [`et::exception_behavior_t`].
 // ///
 // /// `exception_types.h`

--- a/crash-handler/src/mac/signal.rs
+++ b/crash-handler/src/mac/signal.rs
@@ -40,23 +40,9 @@ unsafe extern "C" fn signal_handler(
     // Sanity check
     assert_eq!(signal, libc::SIGABRT);
 
-    let lock = super::state::HANDLER.lock();
-    if let Some(handler) = &*lock {
-        let exc_info = crash_context::ExceptionInfo {
-            kind: ffi::et::EXC_SOFTWARE as i32, // 5
-            code: ffi::EXC_SOFT_SIGNAL as _,    // Unix signal
-            subcode: Some(signal as _),
-        };
-
-        let cc = crash_context::CrashContext {
-            task: ffi::mach_task_self(),
-            thread: ffi::mach_thread_self(),
-            handler_thread: super::state::HANDLER_THREAD
-                .lock()
-                .unwrap_or(ffi::MACH_PORT_NULL),
-            exception: Some(exc_info),
-        };
-
-        handler.crash_event.on_crash(&cc);
-    }
+    super::state::simulate_exception(Some(crash_context::ExceptionInfo {
+        kind: ffi::et::EXC_SOFTWARE as i32, // 5
+        code: ffi::EXC_SOFT_SIGNAL as _,    // Unix signal
+        subcode: Some(signal as _),
+    }));
 }

--- a/crash-handler/src/windows.rs
+++ b/crash-handler/src/windows.rs
@@ -73,6 +73,7 @@ impl CrashHandler {
                 let cc = crash_context::CrashContext {
                     exception_pointers: (&exception_ptrs as *const state::EXCEPTION_POINTERS)
                         .cast(),
+                    process_id: std::process::id(),
                     thread_id: state::GetCurrentThreadId(),
                     exception_code,
                 };

--- a/crash-handler/src/windows/state.rs
+++ b/crash-handler/src/windows/state.rs
@@ -183,6 +183,7 @@ pub(super) unsafe extern "system" fn handle_exception(
 
             match current_handler.user_handler.on_crash(&crate::CrashContext {
                 exception_pointers: except_info.cast(),
+                process_id: std::process::id(),
                 thread_id: GetCurrentThreadId(),
                 exception_code: code,
             }) {
@@ -259,6 +260,7 @@ unsafe extern "C" fn handle_invalid_parameter(
 
             match current_handler.user_handler.on_crash(&crate::CrashContext {
                 exception_pointers: (&exception_ptrs as *const EXCEPTION_POINTERS).cast(),
+                process_id: std::process::id(),
                 thread_id: GetCurrentThreadId(),
                 exception_code: STATUS_INVALID_PARAMETER,
             }) {
@@ -328,6 +330,7 @@ unsafe extern "C" fn handle_pure_virtual_call() {
 
             match current_handler.user_handler.on_crash(&crate::CrashContext {
                 exception_pointers: (&exception_ptrs as *const EXCEPTION_POINTERS).cast(),
+                process_id: std::process::id(),
                 thread_id: GetCurrentThreadId(),
                 exception_code: STATUS_NONCONTINUABLE_EXCEPTION,
             }) {

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -93,7 +93,7 @@ pub fn spinup_server(id: &str) -> Server {
         }
     }
 
-    let server = minidumper::Server::with_name(id).expect("failed to start server");
+    let mut server = minidumper::Server::with_name(id).expect("failed to start server");
 
     struct Inner {
         id: String,

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -4,7 +4,7 @@ use minidumper::{Client, Server};
 
 fn main() {
     if std::env::args().any(|a| a == "--server") {
-        let server = Server::with_name(SOCKET_NAME).expect("failed to create server");
+        let mut server = Server::with_name(SOCKET_NAME).expect("failed to create server");
 
         let ab = std::sync::atomic::AtomicBool::new(false);
 

--- a/minidumper/src/errors.rs
+++ b/minidumper/src/errors.rs
@@ -1,23 +1,38 @@
+/// Error that can occur when creating a [`crate::Client`] or [`crate::Server`],
+/// or generating minidumps
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    /// The provided socket name or path was invalid
     #[error("the socket name is invalid")]
     InvalidName,
+    #[cfg(target_os = "macos")]
+    /// The provided socket name or path was invalid as a Mach port name
+    #[error("the mach port name is invalid")]
+    InvalidPortName,
+    /// An error occurred while creating or communicating with a Mach port
+    #[cfg(target_os = "macos")]
+    #[error("the mach port name is invalid")]
+    PortError(#[from] crash_context::ipc::Error),
+    /// An I/O or other syscall failed
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    /// A crash request received by the server could not be processed as the
+    /// PID for the client process was unknown or invalid
     #[error("client process requesting crash dump has an unknown or invalid pid")]
     UnknownClientPid,
+    /// An error occurred during minidump generation
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[error(transparent)]
     Writer(#[from] minidump_writer::errors::WriterError),
+    /// An error occurred during minidump generation
     #[cfg(target_os = "windows")]
     #[error(transparent)]
     Writer(#[from] minidump_writer::errors::Error),
+    /// An error occurred during minidump generation
     #[cfg(target_os = "macos")]
     #[error(transparent)]
     Writer(#[from] minidump_writer::errors::WriterError),
-    #[cfg(target_os = "windows")]
-    #[error("protocol error, expected tag '{expected}' but received '{received}'")]
-    Protocol { expected: u32, received: u32 },
+    /// An error occurred reading or writing binary data
     #[cfg(any(target_os = "windows", target_os = "macos"))]
     #[error(transparent)]
     Scroll(#[from] scroll::Error),

--- a/minidumper/src/ipc/client.rs
+++ b/minidumper/src/ipc/client.rs
@@ -126,7 +126,14 @@ impl Client {
         }
 
         #[cfg(not(target_os = "macos"))]
-        self.send_message_impl(0, crash_ctx_buffer)
+        {
+            self.send_message_impl(0, crash_ctx_buffer)?;
+            // Wait for the server to send back an ack that it has finished
+            // with the crash context
+            let mut ack = [0u8; 1];
+            self.socket.recv(&mut ack)?;
+            Ok(())
+        }
     }
 
     /// Sends a message to the server.

--- a/minidumper/tests/ipc.rs
+++ b/minidumper/tests/ipc.rs
@@ -5,7 +5,7 @@ use std::sync::{atomic, Arc};
 fn ipc_messages() {
     let name = "ipc_messages";
 
-    let server = minidumper::Server::with_name(name).unwrap();
+    let mut server = minidumper::Server::with_name(name).unwrap();
 
     struct Message {
         kind: u32,


### PR DESCRIPTION
Adds a mach ports based IPC client/server to `crash-context`. As stated in the docs, if using a `crash-context::CrashContext` between processes on MacOS, the information in the context _must_ (for now?) be passed via a mach port, as the port descriptors will be translated (on the sender or the receiver is...unclear) into values that are actually useful. In particular, in a crash process, `mach_task_self()` is used to say the crash occurred in that task, but `mach_task_self` returns the same value in every task, and indeed on every task on every machine on the same kernel! It's only when it is sent over a mach port that the task name will be turned into an actual unique identifier so that a process that wishes to eg. dump that task will not actually be dumping itself.

This also improves the mac exception handler for user signals, and makes the `SIGABRT` signal use a "user signal" underneath, to ensure that the crash context always has a separate handler thread (where the exception port is listening) and a crash thread (where the exception was actually source) as previously they would be the same in the `SIGABRT` case which makes crash analysis more difficult. It also means that explicitly raising an exception will _actually_ wait for the user handler to finish processing it and return a result, rather than just continue on.