### PR TITLE
Add stale client reaping

### DIFF
--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -152,7 +152,7 @@ pub fn spinup_server(id: &str) -> Server {
 
     let run_loop = std::thread::spawn(move || {
         server
-            .run(Box::new(inner), &exit)
+            .run(Box::new(inner), &exit, None)
             .expect("failed to run server loop");
     });
 

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -53,7 +53,7 @@ fn main() {
         }
 
         server
-            .run(Box::new(Handler), &ab)
+            .run(Box::new(Handler), &ab, None)
             .expect("failed to run server");
 
         return;

--- a/minidumper/src/errors.rs
+++ b/minidumper/src/errors.rs
@@ -36,4 +36,6 @@ pub enum Error {
     #[cfg(any(target_os = "windows", target_os = "macos"))]
     #[error(transparent)]
     Scroll(#[from] scroll::Error),
+    #[error("protocol error occurred: {0}")]
+    ProtocolError(&'static str),
 }

--- a/minidumper/src/ipc.rs
+++ b/minidumper/src/ipc.rs
@@ -71,6 +71,7 @@ pub use client::Client;
 pub use server::Server;
 
 const CRASH: u32 = 0;
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 const CRASH_ACK: u32 = 1;
 const PING: u32 = 2;
 const PONG: u32 = 3;

--- a/minidumper/src/ipc.rs
+++ b/minidumper/src/ipc.rs
@@ -70,6 +70,12 @@ mod server;
 pub use client::Client;
 pub use server::Server;
 
+const CRASH: u32 = 0;
+const CRASH_ACK: u32 = 1;
+const PING: u32 = 2;
+const PONG: u32 = 3;
+const USER: u32 = 4;
+
 /// A socket name.
 ///
 /// Linux, Windows, and Macos can all use a file path as the name for the socket.

--- a/minidumper/src/ipc/server.rs
+++ b/minidumper/src/ipc/server.rs
@@ -292,11 +292,11 @@ impl Server {
                             };
 
                             if let Err(e) = clients[pos].socket.send(pong.as_bytes()) {
-                                dbg!(e);
+                                log::error!("failed to send PONG: {}", e);
+
                                 let cc = clients.swap_remove(pos);
                                 Some(cc.socket)
                             } else {
-                                println!("sent PONG");
                                 None
                             }
                         }
@@ -344,7 +344,7 @@ impl Server {
                     let keep = conn.last_update.elapsed() < ka;
 
                     if !keep {
-                        println!("dropping connection {:?}", conn.last_update.elapsed());
+                        log::debug!("dropping stale connection {:?}", conn.last_update.elapsed());
                         if let Err(e) = poll.delete(&conn.socket) {
                             log::error!("failed to deregister timed-out socket: {}", e);
                         }

--- a/minidumper/src/ipc/server.rs
+++ b/minidumper/src/ipc/server.rs
@@ -296,6 +296,7 @@ impl Server {
                                 let cc = clients.swap_remove(pos);
                                 Some(cc.socket)
                             } else {
+                                println!("sent PONG");
                                 None
                             }
                         }
@@ -346,6 +347,8 @@ impl Server {
                         if let Err(e) = poll.delete(&conn.socket) {
                             log::error!("failed to deregister timed-out socket: {}", e);
                         }
+
+                        println!("dropping connection");
                     }
 
                     keep

--- a/minidumper/src/ipc/server.rs
+++ b/minidumper/src/ipc/server.rs
@@ -1,7 +1,7 @@
 use super::{Connection, Header, Listener, SocketName};
 use crate::{Error, LoopAction};
 use polling::{Event, Poller};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Server side of the connection, which runs in the monitor process that is
 /// meant to monitor the process where the [`super::Client`] resides
@@ -23,6 +23,8 @@ struct ClientConn {
     socket: Connection,
     /// The key we associated with the socket
     key: usize,
+    /// Last time a message was sent from the client
+    last_update: Instant,
     /// We pair the pid of the client process so that we know which connection
     /// to drop when a crash is received on the mach port
     #[cfg(target_os = "macos")]
@@ -47,15 +49,21 @@ impl ClientConn {
         }
 
         let header = Header::from_bytes(&hdr_buf)?;
-        let mut buffer = handler.message_alloc();
 
-        buffer.resize(header.size as usize, 0);
+        if header.size == 0 {
+            self.socket.recv(&mut hdr_buf).ok()?;
+            Some((header.kind, Vec::new()))
+        } else {
+            let mut buffer = handler.message_alloc();
 
-        self.socket
-            .recv_vectored(&mut [IoSliceMut::new(&mut hdr_buf), IoSliceMut::new(&mut buffer)])
-            .ok()?;
+            buffer.resize(header.size as usize, 0);
 
-        Some((header.kind, buffer))
+            self.socket
+                .recv_vectored(&mut [IoSliceMut::new(&mut hdr_buf), IoSliceMut::new(&mut buffer)])
+                .ok()?;
+
+            Some((header.kind, buffer))
+        }
     }
 }
 
@@ -136,6 +144,7 @@ impl Server {
         &mut self,
         handler: Box<dyn crate::ServerHandler>,
         shutdown: &std::sync::atomic::AtomicBool,
+        keep_alive: Option<std::time::Duration>,
     ) -> Result<(), Error> {
         let poll = Poller::new()?;
         let mut events = Vec::new();
@@ -171,6 +180,7 @@ impl Server {
                             clients.push(ClientConn {
                                 socket: accepted,
                                 key,
+                                last_update: Instant::now(),
                                 #[cfg(target_os = "macos")]
                                 pid: None,
                             });
@@ -188,8 +198,10 @@ impl Server {
                     // We need to reregister insterest every time
                     poll.modify(self.listener.as_ref().unwrap(), Event::readable(0))?;
                 } else if let Some(pos) = clients.iter().position(|cc| cc.key == event.key) {
+                    clients[pos].last_update = Instant::now();
+
                     let deregister = match clients[pos].recv(handler.as_ref()) {
-                        Some((0, buffer)) => {
+                        Some((super::CRASH, buffer)) => {
                             cfg_if::cfg_if! {
                                 if #[cfg(target_os = "macos")] {
                                     use scroll::Pread;
@@ -255,7 +267,12 @@ impl Server {
                                             }
                                         };
 
-                                    if let Err(e) = cc.socket.send(&[1]) {
+                                    let ack = Header {
+                                        kind: super::CRASH_ACK,
+                                        size: 0,
+                                    };
+
+                                    if let Err(e) = cc.socket.send(ack.as_bytes()) {
                                         log::error!("failed to send ack: {}", e);
                                     }
 
@@ -268,9 +285,23 @@ impl Server {
                                 }
                             }
                         }
+                        Some((super::PING, _buffer)) => {
+                            let pong = Header {
+                                kind: super::PONG,
+                                size: 0,
+                            };
+
+                            if let Err(_e) = clients[pos].socket.send(pong.as_bytes()) {
+                                let cc = clients.swap_remove(pos);
+                                Some(cc.socket)
+                            } else {
+                                None
+                            }
+                        }
+                        Some((super::PONG, _buffer)) => None,
                         Some((kind, buffer)) => {
                             handler.on_message(
-                                kind - 1, /* give the user back the original code they specified */
+                                kind - super::USER, /* give the user back the original code they specified */
                                 buffer,
                             );
 
@@ -300,6 +331,30 @@ impl Server {
                     } else {
                         poll.modify(&clients[pos].socket, Event::readable(clients[pos].key))?;
                     }
+                }
+            }
+
+            if let Some(ka) = keep_alive {
+                // Reap any connections that haven't sent a message within the keep_alive window
+                let before = clients.len();
+
+                clients.retain(|conn| {
+                    let keep = conn.last_update.elapsed() < ka;
+
+                    if !keep {
+                        if let Err(e) = poll.delete(&conn.socket) {
+                            log::error!("failed to deregister timed-out socket: {}", e);
+                        }
+                    }
+
+                    keep
+                });
+
+                if before > clients.len()
+                    && handler.on_client_disconnected(clients.len()) == LoopAction::Exit
+                {
+                    log::debug!("on_client_disconnected exited message loop");
+                    return Ok(());
                 }
             }
         }

--- a/minidumper/src/ipc/server.rs
+++ b/minidumper/src/ipc/server.rs
@@ -344,11 +344,10 @@ impl Server {
                     let keep = conn.last_update.elapsed() < ka;
 
                     if !keep {
+                        println!("dropping connection {:?}", conn.last_update.elapsed());
                         if let Err(e) = poll.delete(&conn.socket) {
                             log::error!("failed to deregister timed-out socket: {}", e);
                         }
-
-                        println!("dropping connection");
                     }
 
                     keep

--- a/minidumper/src/ipc/server.rs
+++ b/minidumper/src/ipc/server.rs
@@ -291,7 +291,8 @@ impl Server {
                                 size: 0,
                             };
 
-                            if let Err(_e) = clients[pos].socket.send(pong.as_bytes()) {
+                            if let Err(e) = clients[pos].socket.send(pong.as_bytes()) {
+                                dbg!(e);
                                 let cc = clients.swap_remove(pos);
                                 Some(cc.socket)
                             } else {

--- a/minidumper/src/ipc/windows.rs
+++ b/minidumper/src/ipc/windows.rs
@@ -238,7 +238,10 @@ impl IntoRawSocket for Socket {
 impl Drop for Socket {
     fn drop(&mut self) {
         // SAFETY: syscall
-        let _ = unsafe { ws::closesocket(self.0) };
+        let _ = unsafe {
+            ws::shutdown(self.0);
+            ws::closesocket(self.0)
+        };
     }
 }
 

--- a/minidumper/src/ipc/windows.rs
+++ b/minidumper/src/ipc/windows.rs
@@ -240,7 +240,7 @@ impl Drop for Socket {
         // SAFETY: syscalls
         let _ = unsafe {
             // https://docs.microsoft.com/en-us/windows/win32/winsock/graceful-shutdown-linger-options-and-socket-closure-2
-            if ws::shutdown(self.0, ws::SD_SEND) == 0 {
+            if ws::shutdown(self.0, ws::SD_SEND /* 1 */ as i32) == 0 {
                 // Loop until we've received all data
                 let mut chunk = [0u8; 1024];
                 while let Ok(sz) = self.recv_with_flags(&mut chunk, 0) {

--- a/minidumper/tests/ipc.rs
+++ b/minidumper/tests/ipc.rs
@@ -215,7 +215,7 @@ fn ping() {
     let elapsed = dbg!(start.elapsed());
 
     assert!(
-        elapsed < std::time::Duration::from_millis(60)
+        elapsed < std::time::Duration::from_millis(60 + 30 /* account for potato computers */)
             && elapsed > std::time::Duration::from_millis(45)
     );
 

--- a/minidumper/tests/ipc.rs
+++ b/minidumper/tests/ipc.rs
@@ -211,7 +211,8 @@ fn ping() {
 
     server_loop.join().unwrap().unwrap();
 
-    let elapsed = start.elapsed();
+    #[allow(clippy::dbg_macro)]
+    let elapsed = dbg!(start.elapsed());
 
     assert!(
         elapsed < std::time::Duration::from_millis(60)

--- a/minidumper/tests/ipc.rs
+++ b/minidumper/tests/ipc.rs
@@ -96,16 +96,16 @@ fn inactive_reap() {
 
         fn on_message(&self, _kind: u32, buffer: Vec<u8>) {
             self.messages.lock().push(Message {
-                msg: dbg!(String::from_utf8(buffer).unwrap()),
+                msg: String::from_utf8(buffer).unwrap(),
             });
         }
 
         fn on_client_disconnected(&self, num_clients: usize) -> minidumper::LoopAction {
             self.messages.lock().push(Message {
-                msg: dbg!(format!("num_clients = {num_clients}")),
+                msg: format!("num_clients = {num_clients}"),
             });
 
-            if dbg!(num_clients == 0) {
+            if num_clients == 0 {
                 minidumper::LoopAction::Exit
             } else {
                 minidumper::LoopAction::Continue
@@ -205,7 +205,8 @@ fn ping() {
     let start = std::time::Instant::now();
     for i in 0..3 {
         std::thread::sleep(std::time::Duration::from_millis(10));
-        assert!(client.ping().is_ok(), "ping {i}");
+        let res = client.ping();
+        assert!(res.is_ok(), "ping {i} {res:?}");
     }
 
     server_loop.join().unwrap().unwrap();

--- a/minidumper/tests/ipc.rs
+++ b/minidumper/tests/ipc.rs
@@ -120,11 +120,10 @@ fn inactive_reap() {
     };
 
     let shutdown = Arc::new(atomic::AtomicBool::new(false));
-    let is_shutdown = shutdown.clone();
     let server_loop = std::thread::spawn(move || {
         server.run(
             Box::new(server_handler),
-            &is_shutdown,
+            &shutdown,
             Some(std::time::Duration::from_millis(20)),
         )
     });
@@ -193,11 +192,10 @@ fn ping() {
     let server_handler = Server;
 
     let shutdown = Arc::new(atomic::AtomicBool::new(false));
-    let is_shutdown = shutdown.clone();
     let server_loop = std::thread::spawn(move || {
         server.run(
             Box::new(server_handler),
-            &is_shutdown,
+            &shutdown,
             Some(std::time::Duration::from_millis(20)),
         )
     });

--- a/minidumper/tests/ipc.rs
+++ b/minidumper/tests/ipc.rs
@@ -68,7 +68,6 @@ fn ipc_messages() {
 /// Tests that the server reaps inactive clients
 #[test]
 fn inactive_reap() {
-    #[cfg(target_os = "macos")]
     if std::env::var("CI").is_ok() {
         println!("not potato compatible");
         return;
@@ -162,7 +161,6 @@ fn inactive_reap() {
 
 #[test]
 fn ping() {
-    #[cfg(target_os = "macos")]
     if std::env::var("CI").is_ok() {
         println!("not potato compatible");
         return;

--- a/minidumper/tests/ipc.rs
+++ b/minidumper/tests/ipc.rs
@@ -68,6 +68,12 @@ fn ipc_messages() {
 /// Tests that the server reaps inactive clients
 #[test]
 fn inactive_reap() {
+    #[cfg(target_os = "macos")]
+    if std::env::var("CI").is_ok() {
+        println!("not potato compatible");
+        return;
+    }
+
     let name = "inactive_reap";
 
     let mut server = minidumper::Server::with_name(name).unwrap();
@@ -156,6 +162,12 @@ fn inactive_reap() {
 
 #[test]
 fn ping() {
+    #[cfg(target_os = "macos")]
+    if std::env::var("CI").is_ok() {
+        println!("not potato compatible");
+        return;
+    }
+
     let name = "ping";
 
     let mut server = minidumper::Server::with_name(name).unwrap();

--- a/minidumper/tests/ipc.rs
+++ b/minidumper/tests/ipc.rs
@@ -47,7 +47,7 @@ fn ipc_messages() {
     let shutdown = Arc::new(atomic::AtomicBool::new(false));
     let is_shutdown = shutdown.clone();
     let server_loop =
-        std::thread::spawn(move || server.run(Box::new(server_handler), &is_shutdown));
+        std::thread::spawn(move || server.run(Box::new(server_handler), &is_shutdown, None));
 
     let client = minidumper::Client::with_name(name).unwrap();
 
@@ -63,4 +63,94 @@ fn ipc_messages() {
         assert_eq!(i, msg.kind);
         assert_eq!(format!("msg #{i}"), msg.msg);
     }
+}
+
+/// Tests that the server reaps inactive clients
+#[test]
+fn inactive_reap() {
+    let name = "inactive_reap";
+
+    let mut server = minidumper::Server::with_name(name).unwrap();
+
+    struct Message {
+        msg: String,
+    }
+
+    struct Server {
+        messages: Arc<parking_lot::Mutex<Vec<Message>>>,
+    }
+
+    impl minidumper::ServerHandler for Server {
+        fn create_minidump_file(
+            &self,
+        ) -> Result<(std::fs::File, std::path::PathBuf), std::io::Error> {
+            panic!("should not be called");
+        }
+
+        fn on_minidump_created(
+            &self,
+            _result: Result<minidumper::MinidumpBinary, minidumper::Error>,
+        ) -> minidumper::LoopAction {
+            panic!("should not be called");
+        }
+
+        fn on_message(&self, _kind: u32, buffer: Vec<u8>) {
+            self.messages.lock().push(Message {
+                msg: dbg!(String::from_utf8(buffer).unwrap()),
+            });
+        }
+
+        fn on_client_disconnected(&self, num_clients: usize) -> minidumper::LoopAction {
+            self.messages.lock().push(Message {
+                msg: dbg!(format!("num_clients = {num_clients}")),
+            });
+
+            if dbg!(num_clients == 0) {
+                minidumper::LoopAction::Exit
+            } else {
+                minidumper::LoopAction::Continue
+            }
+        }
+    }
+
+    let messages = Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+    let server_handler = Server {
+        messages: messages.clone(),
+    };
+
+    let shutdown = Arc::new(atomic::AtomicBool::new(false));
+    let is_shutdown = shutdown.clone();
+    let server_loop = std::thread::spawn(move || {
+        server.run(
+            Box::new(server_handler),
+            &is_shutdown,
+            Some(std::time::Duration::from_millis(20)),
+        )
+    });
+
+    let client_one = minidumper::Client::with_name(name).unwrap();
+    let client_two = minidumper::Client::with_name(name).unwrap();
+
+    client_one.send_message(1, "msg #1").expect("1");
+    client_two.send_message(2, "msg #2").expect("2");
+
+    std::thread::sleep(std::time::Duration::from_millis(12));
+
+    client_one.ping().expect("ping");
+
+    std::thread::sleep(std::time::Duration::from_millis(12));
+
+    client_one.send_message(1, "msg #3").expect("3");
+
+    server_loop.join().unwrap().unwrap();
+
+    let messages = messages.lock();
+
+    assert_eq!(messages.len(), 5);
+    assert_eq!(messages[0].msg, "msg #1");
+    assert_eq!(messages[1].msg, "msg #2");
+    assert_eq!(messages[2].msg, "num_clients = 1");
+    assert_eq!(messages[3].msg, "msg #3");
+    assert_eq!(messages[4].msg, "num_clients = 0");
 }


### PR DESCRIPTION
On Windows we've noticed an issue where killing a client process, and thus not going through the normal client shutdown process, will cause the crash monitor process to stay alive indefinitely, either due to a bug in Windows handling of unix domain sockets, or just taking longer than is reasonable to reap the resources of the killed process. This PR adds a simple `stale_timeout` to the `Server::run` to optionally check that each client connection has sent a message within the specified window, and if not, close the connection on the server side. To help, a `Client::ping` method has been added so that pings can be sent to server to indicate the client is still alive, in case the client is not sending messages frequently to the server to indicate it is still alive.