### PR TITLE
Don't crash in crash handler on aarch64 Linux

### DIFF
--- a/crash-handler/src/linux/state.rs
+++ b/crash-handler/src/linux/state.rs
@@ -429,7 +429,7 @@ impl HandlerInner {
                     let fp_ptr = uc_ptr.uc_mcontext.__reserved.as_ptr().cast::<crash_context::fpsimd_context>();
 
                     if (*fp_ptr).head.magic == crash_context::FPSIMD_MAGIC {
-                        ptr::copy_nonoverlapping(fp_ptr, &mut cc.float_state, mem::size_of::<crash_context::fpregset_t>());
+                        ptr::copy_nonoverlapping(fp_ptr, &mut cc.float_state, 1);
                     }
                 } else if #[cfg(not(target_arch = "arm"))] {
                     if !uc_ptr.uc_mcontext.fpregs.is_null() {


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Only copy a single instance of SIMD register context in the aarch64-specific logic. Otherwise we run off the end of the signal stack and SIGBUS.

### Related Issues

Closes #42 
