### PR TITLE
Add support for EXC_GUARD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ members = [
 
 [profile.dev]
 debug = 2
+
+[patch.crates-io]
+minidump-writer = { git = "https://github.com/rust-minidump/minidump-writer", branch = "exc-encoding" }
+#minidump-writer = { path = "../mdw" }
+crash-context = { path = "crash-context" }

--- a/crash-context/src/mac.rs
+++ b/crash-context/src/mac.rs
@@ -2,17 +2,20 @@ pub mod guard;
 pub mod ipc;
 pub mod resource;
 
-use mach2::{exception_types as et, mach_types as mt};
+use mach2::mach_types as mt;
 
 /// Information on the exception that caused the crash
 #[derive(Copy, Clone, Debug)]
 pub struct ExceptionInfo {
     /// The exception kind
-    pub kind: et::exception_type_t,
+    pub kind: u32,
     /// The exception code
-    pub code: et::mach_exception_data_type_t,
-    /// Optional subcode, typically only present for `EXC_BAD_ACCESS` exceptions
-    pub subcode: Option<et::mach_exception_data_type_t>,
+    pub code: u64,
+    /// Optional subcode with different meanings depending on the exception type
+    /// * `EXC_BAD_ACCESS` - The address that caused the exception
+    /// * `EXC_GUARD` - The unique guard identifier that was guarding a resource
+    /// * `EXC_RESOURCE` - Additional details depending on the resource type
+    pub subcode: Option<u64>,
 }
 
 /// Full Macos crash context

--- a/crash-context/src/mac.rs
+++ b/crash-context/src/mac.rs
@@ -1,3 +1,4 @@
+pub mod guard;
 pub mod ipc;
 pub mod resource;
 

--- a/crash-context/src/mac/guard.rs
+++ b/crash-context/src/mac/guard.rs
@@ -1,0 +1,150 @@
+//! Contains types and helpers for dealing with `EXC_GUARD` exceptions.
+//!
+//! `EXC_GUARD` exceptions embed details about the guarded resource in the `code`
+//! and `subcode` fields of the exception
+//!
+//! See <https://github.com/apple-oss-distributions/xnu/blob/e7776783b89a353188416a9a346c6cdb4928faad/osfmk/kern/exc_guard.h>
+//! for the top level types that this module wraps.
+
+use mach2::exception_types::EXC_GUARD;
+
+/// The set of possible guard kinds
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+pub enum GuardKind {
+    /// Null variant
+    None = 0,
+    /// A `mach_port_t`
+    MachPort = 1,
+    /// File descriptor
+    Fd = 2,
+    /// Userland assertion
+    User = 3,
+    /// Vnode
+    Vnode = 4,
+    /// Virtual memory operation
+    VirtualMemory = 5,
+    /// Rejected system call trap
+    RejectedSyscall = 6,
+}
+
+#[inline]
+pub fn extract_guard_kind(code: i64) -> u8 {
+    ((code >> 61) & 0x7) as u8
+}
+
+#[inline]
+pub fn extract_guard_flavor(code: i64) -> u32 {
+    ((code >> 32) & 0x1fffffff) as u32
+}
+
+#[inline]
+pub fn extract_guard_target(code: i64) -> u32 {
+    code as u32
+}
+
+/// The extracted details of an `EXC_GUARD` exception
+pub struct GuardException {
+    /// One of [`GuardKind`]
+    pub kind: u8,
+    /// The specific guard flavor that was violated, specific to each `kind`
+    pub flavor: u32,
+    /// The resource that was guarded
+    pub target: u32,
+    /// Target specific guard information
+    pub identifier: u64,
+}
+
+/// Extracts the guard details from an exceptions code and subcode
+///
+/// code:
+/// +-------------------+----------------+--------------+
+/// |[63:61] guard type | [60:32] flavor | [31:0] target|
+/// +-------------------+----------------+--------------+
+///
+/// subcode:
+/// +---------------------------------------------------+
+/// |[63:0] guard identifier                            |
+/// +---------------------------------------------------+
+#[inline]
+pub fn extract_guard_exception(code: i64, subcode: i64) -> GuardException {
+    GuardDetails {
+        kind: extract_guard_kind(code),
+        flavor: extract_guard_flavor(code),
+        target: extract_guard_target(code),
+        identifier: subcode as u64,
+    }
+}
+
+impl super::ExceptionInfo {
+    /// If this is an `EXC_GUARD` exception, retrieves the exception metadata
+    /// from the code, otherwise returns `None`
+    pub fn guard_exception(&self) -> Option<GuardException> {
+        if self.kind as u32 != EXC_GUARD {
+            return None;
+        }
+
+        Some(extract_guard_exception(
+            self.code,
+            self.subcode.unwrap_or_default(),
+        ))
+    }
+}
+
+// /// Mach port guard flavors
+// ///
+// /// [Kernel source](https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/port.h#L469-L496)
+// #[derive(Copy, Clone, PartialEq, Debug)]
+// #[repr(u32)]
+// pub enum MachPortFlavors {
+//     // Fatal guards
+//     Destroy = 1 << 0,
+//     ModRefs = 1 << 1,
+//     SetContext = 1 << 2,
+//     Unguarded = 1 << 3,
+//     IncorrectGuard = 1 << 4,
+//     Immovable = 1 << 5,
+//     StrictReply = 1 << 6,
+//     MsgFiltered = 1 << 7,
+
+//     // Optionally fatal guards
+//     InvalidRight = 1 << 8,
+//     InvalidName = 1 << 9,
+//     InvalidValue = 1 << 10,
+//     InvalidArgument = 1 << 11,
+//     RightExists = 1 << 12,
+//     KernNoSpace = 1 << 13,
+//     KernFailure = 1 << 14,
+//     KernResource = 1 << 15,
+//     SendInvalidReply = 1 << 16,
+//     SendInvalidVoucher = 1 << 17,
+//     SendInvalidRight = 1 << 18,
+//     ReceiveInvalidName = 1 << 19,
+
+//     // Non-fatal guards
+//     ReceiveGuardedDesc = 1 << 20,
+//     ModRefsNonFatal = 1 << 1,
+// }
+
+// /// Mach port guards can be either always, never, or optionally fatal
+// #[derive(Copy, Clone PartialEq, Debug)]
+// pub enum Fatal {
+//     Yes,
+//     No,
+//     Optional,
+// }
+
+// impl MachPortFlavors {
+//     /// Retrieves whether the exception is fatal or not
+//     pub fn fatal(self) -> Fatal {
+//         if self as u32 <= Self::MsgFiltered as u32 {
+//             Fatal::Yes
+//         } else if self as u32 >= Self::ReceiveGuardedDesc as u32 {
+//             Fatal::No
+//         } else {
+//             Fatal::Optional
+//         }
+//     }
+// }
+
+// pub struct MachPortException {}

--- a/crash-context/src/mac/guard.rs
+++ b/crash-context/src/mac/guard.rs
@@ -29,17 +29,17 @@ pub enum GuardKind {
 }
 
 #[inline]
-pub fn extract_guard_kind(code: i64) -> u8 {
+pub fn extract_guard_kind(code: u64) -> u8 {
     ((code >> 61) & 0x7) as u8
 }
 
 #[inline]
-pub fn extract_guard_flavor(code: i64) -> u32 {
+pub fn extract_guard_flavor(code: u64) -> u32 {
     ((code >> 32) & 0x1fffffff) as u32
 }
 
 #[inline]
-pub fn extract_guard_target(code: i64) -> u32 {
+pub fn extract_guard_target(code: u64) -> u32 {
     code as u32
 }
 
@@ -67,12 +67,12 @@ pub struct GuardException {
 /// |[63:0] guard identifier                            |
 /// +---------------------------------------------------+
 #[inline]
-pub fn extract_guard_exception(code: i64, subcode: i64) -> GuardException {
-    GuardDetails {
+pub fn extract_guard_exception(code: u64, subcode: u64) -> GuardException {
+    GuardException {
         kind: extract_guard_kind(code),
         flavor: extract_guard_flavor(code),
         target: extract_guard_target(code),
-        identifier: subcode as u64,
+        identifier: subcode,
     }
 }
 
@@ -80,7 +80,7 @@ impl super::ExceptionInfo {
     /// If this is an `EXC_GUARD` exception, retrieves the exception metadata
     /// from the code, otherwise returns `None`
     pub fn guard_exception(&self) -> Option<GuardException> {
-        if self.kind as u32 != EXC_GUARD {
+        if self.kind != EXC_GUARD {
             return None;
         }
 
@@ -90,61 +90,3 @@ impl super::ExceptionInfo {
         ))
     }
 }
-
-// /// Mach port guard flavors
-// ///
-// /// [Kernel source](https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/port.h#L469-L496)
-// #[derive(Copy, Clone, PartialEq, Debug)]
-// #[repr(u32)]
-// pub enum MachPortFlavors {
-//     // Fatal guards
-//     Destroy = 1 << 0,
-//     ModRefs = 1 << 1,
-//     SetContext = 1 << 2,
-//     Unguarded = 1 << 3,
-//     IncorrectGuard = 1 << 4,
-//     Immovable = 1 << 5,
-//     StrictReply = 1 << 6,
-//     MsgFiltered = 1 << 7,
-
-//     // Optionally fatal guards
-//     InvalidRight = 1 << 8,
-//     InvalidName = 1 << 9,
-//     InvalidValue = 1 << 10,
-//     InvalidArgument = 1 << 11,
-//     RightExists = 1 << 12,
-//     KernNoSpace = 1 << 13,
-//     KernFailure = 1 << 14,
-//     KernResource = 1 << 15,
-//     SendInvalidReply = 1 << 16,
-//     SendInvalidVoucher = 1 << 17,
-//     SendInvalidRight = 1 << 18,
-//     ReceiveInvalidName = 1 << 19,
-
-//     // Non-fatal guards
-//     ReceiveGuardedDesc = 1 << 20,
-//     ModRefsNonFatal = 1 << 1,
-// }
-
-// /// Mach port guards can be either always, never, or optionally fatal
-// #[derive(Copy, Clone PartialEq, Debug)]
-// pub enum Fatal {
-//     Yes,
-//     No,
-//     Optional,
-// }
-
-// impl MachPortFlavors {
-//     /// Retrieves whether the exception is fatal or not
-//     pub fn fatal(self) -> Fatal {
-//         if self as u32 <= Self::MsgFiltered as u32 {
-//             Fatal::Yes
-//         } else if self as u32 >= Self::ReceiveGuardedDesc as u32 {
-//             Fatal::No
-//         } else {
-//             Fatal::Optional
-//         }
-//     }
-// }
-
-// pub struct MachPortException {}

--- a/crash-context/src/mac/resource.rs
+++ b/crash-context/src/mac/resource.rs
@@ -40,9 +40,9 @@ pub enum Flavor<T: Copy + Clone + std::fmt::Debug> {
     Unknown(u8),
 }
 
-impl<T: TryFrom<u8> + Copy + Clone + std::fmt::Debug> From<i64> for Flavor<T> {
+impl<T: TryFrom<u8> + Copy + Clone + std::fmt::Debug> From<u64> for Flavor<T> {
     #[inline]
-    fn from(code: i64) -> Self {
+    fn from(code: u64) -> Self {
         let flavor = resource_exc_flavor(code);
         if let Ok(known) = T::try_from(flavor) {
             Self::Known(known)
@@ -63,13 +63,13 @@ impl<T: PartialEq + Copy + Clone + std::fmt::Debug> PartialEq<T> for Flavor<T> {
 
 /// Retrieves the resource exception kind from an exception code
 #[inline]
-pub fn resource_exc_kind(code: i64) -> u8 {
+pub fn resource_exc_kind(code: u64) -> u8 {
     ((code >> 61) & 0x7) as u8
 }
 
 /// Retrieves the resource exception flavor from an exception code
 #[inline]
-pub fn resource_exc_flavor(code: i64) -> u8 {
+pub fn resource_exc_flavor(code: u64) -> u8 {
     ((code >> 58) & 0x7) as u8
 }
 
@@ -77,7 +77,7 @@ impl super::ExceptionInfo {
     /// If this is an `EXC_RESOURCE` exception, retrieves the exception metadata
     /// from the code, otherwise returns `None`
     pub fn resource_exception(&self) -> Option<ResourceException> {
-        if self.kind as u32 != EXC_RESOURCE {
+        if self.kind != EXC_RESOURCE {
             return None;
         }
 
@@ -181,7 +181,7 @@ impl CpuResourceException {
      *
      */
     #[inline]
-    pub fn from_exc_info(code: i64, subcode: Option<i64>) -> Self {
+    pub fn from_exc_info(code: u64, subcode: Option<u64>) -> Self {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Cpu as u8);
 
         let flavor = Flavor::from(code);
@@ -256,7 +256,7 @@ impl WakeupsResourceException {
      *
      */
     #[inline]
-    pub fn from_exc_info(code: i64, subcode: Option<i64>) -> Self {
+    pub fn from_exc_info(code: u64, subcode: Option<u64>) -> Self {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Wakeups as u8);
 
         let flavor = Flavor::from(code);
@@ -323,7 +323,7 @@ impl MemoryResourceException {
      *
      */
     #[inline]
-    pub fn from_exc_info(code: i64) -> Self {
+    pub fn from_exc_info(code: u64) -> Self {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Memory as u8);
 
         let flavor = Flavor::from(code);
@@ -384,7 +384,7 @@ impl IoResourceException {
      *
      */
     #[inline]
-    pub fn from_exc_info(code: i64, subcode: Option<i64>) -> Self {
+    pub fn from_exc_info(code: u64, subcode: Option<u64>) -> Self {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Io as u8);
 
         let flavor = Flavor::from(code);
@@ -447,7 +447,7 @@ impl ThreadsResourceException {
      *
      */
     #[inline]
-    pub fn from_exc_info(code: i64) -> Self {
+    pub fn from_exc_info(code: u64) -> Self {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Threads as u8);
 
         let flavor = Flavor::from(code);
@@ -505,7 +505,7 @@ impl PortsResourceException {
      *
      */
     #[inline]
-    pub fn from_exc_info(code: i64) -> Self {
+    pub fn from_exc_info(code: u64) -> Self {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Ports as u8);
 
         let flavor = Flavor::from(code);

--- a/crash-context/src/mac/resource.rs
+++ b/crash-context/src/mac/resource.rs
@@ -1,7 +1,7 @@
 //! Contains types and helpers for dealing with `EXC_RESOURCE` exceptions.
 //!
 //! `EXC_RESOURCE` exceptions embed details about the resource and the limits
-//! it exceeded within the `code` and, in some cases, `subcode` fields of the exception
+//! it exceeded within the `code` and, in some cases `subcode`, fields of the exception
 //!
 //! See <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/kern/exc_resource.h>
 //! for the various constants and decoding of exception information wrapped in
@@ -76,7 +76,7 @@ pub fn resource_exc_flavor(code: i64) -> u8 {
 impl super::ExceptionInfo {
     /// If this is an `EXC_RESOURCE` exception, retrieves the exception metadata
     /// from the code, otherwise returns `None`
-    pub fn get_resource_info(&self) -> Option<ResourceException> {
+    pub fn resource_exception(&self) -> Option<ResourceException> {
         if self.kind as u32 != EXC_RESOURCE {
             return None;
         }

--- a/crash-handler/src/mac/ffi.rs
+++ b/crash-handler/src/mac/ffi.rs
@@ -62,7 +62,7 @@ cfg_if::cfg_if! {
 ///
 /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/ndr.h#L40-L49>
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub struct NdrRecord {
     pub mig_vers: u8,
     pub if_vers: u8,
@@ -76,7 +76,6 @@ pub struct NdrRecord {
 
 /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/message.h#L379-L391>
 #[repr(C, packed(4))]
-#[derive(Debug)]
 pub struct MachMsgPortDescriptor {
     pub name: u32,
     __pad1: u32,
@@ -86,14 +85,12 @@ pub struct MachMsgPortDescriptor {
 }
 
 #[repr(C, packed(4))]
-#[derive(Debug)]
 pub struct MachMsgBody {
     pub descriptor_count: u32,
 }
 
 /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/message.h#L545-L552>
 #[repr(C, packed(4))]
-#[derive(Debug)]
 pub struct MachMsgHeader {
     pub bits: u32,
     pub size: u32,
@@ -105,7 +102,6 @@ pub struct MachMsgHeader {
 
 /// https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/message.h#L585-L588
 #[repr(C, packed(4))]
-#[derive(Debug)]
 pub struct MachMsgTrailer {
     pub kind: u32,
     pub size: u32,
@@ -113,7 +109,6 @@ pub struct MachMsgTrailer {
 
 /// This structure can be obtained by running `mig <path to OSX SDK>/usr/include/mach_exc.defs`
 #[repr(C, packed(4))]
-#[derive(Debug)]
 pub struct ExceptionMessage {
     pub header: MachMsgHeader,
     /* start of the kernel processed data */

--- a/crash-handler/src/mac/ffi.rs
+++ b/crash-handler/src/mac/ffi.rs
@@ -1,12 +1,5 @@
-//! Due to Apple's ~fucking~ terrible documentation, these structures/code where
-//! mainly copied from wasmtime's Mac traphandler (which themselves were
-//! primarily copied from Spider Monkey) and Breakpad. I just wish Apple had
-//! enough resources to properly document their own APIs OH WAIT. I was going
-//! to clean this comment up when I was less salty, but turns out I'm still
-//! salty so it's staying up.
-//!
-//! All the bindings here are lifted from headers in usr/include/mach, each one
-//! notes the specific header it can be located in
+//! Additional bindings not (or incorrectly) exposed by the [`mach2`] crate.
+//! These are lifted from <https://github.com/apple-oss-distributions/xnu>
 
 pub use mach2::{
     exception_types as et,
@@ -20,43 +13,25 @@ pub use mach2::{
 
 /// Number of top level exception types
 ///
-/// This is platform independent, but located the `<arch>/exception.h`
+/// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/arm/exception.h#L34>
+/// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/i386/exception.h#L68>
 pub const EXC_TYPES_COUNT: usize = 14;
 /// For `EXC_SOFTWARE` exceptions, this indicates the exception was due to a Unix signal
 ///
 /// The actual Unix signal is stored in the subcode of the exception
 ///
-/// `exception_types.h`
+/// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/exception_types.h#L176-L182>
 pub const EXC_SOFT_SIGNAL: u32 = 0x10003;
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-        /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/i386/thread_status.h#L112>
-        /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/i386/thread_status.h#L363>
-        pub const MACHINE_THREAD_STATE: ts::thread_state_flavor_t = 7;
+        /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/i386/thread_status.h#L118>
         pub const THREAD_STATE_NONE: ts::thread_state_flavor_t = 13;
     } else if #[cfg(any(target_arch = "arm", target_arch = "aarch64"))] {
-        /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/arm/thread_status.h#L52>
-        /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/arm/thread_status.h#L239>
-        pub const MACHINE_THREAD_STATE: ts::thread_state_flavor_t = 1;
+        /// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/arm/thread_status.h#L57>
         pub const THREAD_STATE_NONE: ts::thread_state_flavor_t = 5;
     }
 }
-
-// /// Machine-independent exception behaviors. Possible values for [`et::exception_behavior_t`].
-// ///
-// /// `exception_types.h`
-// #[repr(i32)]
-// pub enum ExceptionBehaviors {
-//     /// Send a `catch_exception_raise` message including the identity.
-//     Default = 1,
-//     /// Send a `catch_exception_raise_state` message including the thread state.
-//     State = 2,
-//     /// Send a `catch_exception_raise_state_identity` message including the thread identity and state.
-//     StateIdentity = 3,
-//     /// Send a catch_exception_raise message including protected task and thread identity.
-//     IdentityProtected = 4,
-// }
 
 /// Network Data Representation Record
 ///
@@ -100,7 +75,7 @@ pub struct MachMsgHeader {
     pub id: u32,
 }
 
-/// https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/message.h#L585-L588
+/// <https://github.com/apple-oss-distributions/xnu/blob/e6231be02a03711ca404e5121a151b24afbff733/osfmk/mach/message.h#L585-L588>
 #[repr(C, packed(4))]
 pub struct MachMsgTrailer {
     pub kind: u32,
@@ -136,6 +111,10 @@ pub struct ExceptionRaiseReply {
 }
 
 extern "C" {
+    /// Set an exception handler for a thread on one or more exception types.
+    /// At the same time, return the previously defined exception handlers for
+    /// those types.
+    ///
     /// Atomically (I assume) swaps the currently registered exception ports
     /// with a new one, returning the previously registered ports so that
     /// they can be restored later.
@@ -145,7 +124,7 @@ extern "C" {
     /// Breakpad), the output of this function will be 4 distinct arrays,
     /// which are basically a structure of arrays
     ///
-    /// task.h
+    /// <https://github.com/apple-oss-distributions/xnu/blob/e7776783b89a353188416a9a346c6cdb4928faad/osfmk/mach/task.defs#L281-L295>
     pub fn task_swap_exception_ports(
         task: mt::task_t,                      // The task we want to swap the ports for
         exception_mask: et::exception_mask_t, // The mask of exceptions, will only swaps ports that match an exception in the mask
@@ -159,9 +138,12 @@ extern "C" {
         old_flavors: *mut ts::thread_state_flavor_t, // Output array of thread flavors
     ) -> kern_return_t;
 
-    /// Sets a new exception port for the specified exception.
+    /// Set an exception handler for a task on one or more exception types.
+    /// These handlers are invoked for all threads in the task if there are
+    /// no thread-specific exception handlers or those handlers returned an
+    /// error.
     ///
-    /// task.h
+    /// <https://github.com/apple-oss-distributions/xnu/blob/e7776783b89a353188416a9a346c6cdb4928faad/osfmk/mach/task.defs#L249-L260>
     pub fn task_set_exception_ports(
         task: mt::task_t,                      // The task we want to set the port for
         exception_mask: et::exception_mask_t,  // The exception we want to set the port for
@@ -172,6 +154,7 @@ extern "C" {
 
     /// The host? NDR
     ///
-    /// <arch>/ndr_def.h
+    /// <https://github.com/apple-oss-distributions/xnu/blob/e7776783b89a353188416a9a346c6cdb4928faad/osfmk/mach/arm/ndr_def.h#L36-L45>
+    /// <https://github.com/apple-oss-distributions/xnu/blob/e7776783b89a353188416a9a346c6cdb4928faad/osfmk/mach/i386/ndr_def.h#L36-L45>
     pub static NDR_record: NdrRecord;
 }

--- a/crash-handler/src/mac/signal.rs
+++ b/crash-handler/src/mac/signal.rs
@@ -46,8 +46,8 @@ unsafe extern "C" fn signal_handler(
     assert_eq!(signal, libc::SIGABRT);
 
     super::state::simulate_exception(Some(crash_context::ExceptionInfo {
-        kind: ffi::et::EXC_SOFTWARE as i32, // 5
-        code: ffi::EXC_SOFT_SIGNAL as _,    // Unix signal
+        kind: ffi::et::EXC_SOFTWARE,
+        code: ffi::EXC_SOFT_SIGNAL as u64, // Unix signal
         subcode: Some(signal as _),
     }));
 }

--- a/crash-handler/tests/guard.rs
+++ b/crash-handler/tests/guard.rs
@@ -1,0 +1,8 @@
+#![cfg(target_os = "macos")]
+
+mod shared;
+
+#[test]
+fn handles_guard() {
+    shared::handles_crash(shared::SadnessFlavor::Guard);
+}

--- a/crash-handler/tests/shared.rs
+++ b/crash-handler/tests/shared.rs
@@ -46,7 +46,15 @@ pub fn handles_crash(flavor: SadnessFlavor) {
                             }
                             SadnessFlavor::Bus
                             | SadnessFlavor::Segfault
-                            | SadnessFlavor::StackOverflow { .. } => ExceptionType::BadAccess,
+                            | SadnessFlavor::StackOverflow { .. } => {
+                                if flavor == SadnessFlavor::Segfault {
+                                    // For EXC_BAD_ACCESS exceptions, the subcode will be the
+                                    // bad address we tried to access
+                                    assert_eq!(cc.exception.unwrap().subcode.unwrap(), sadness_generator::SEGFAULT_ADDRESS as _);
+                                }
+
+                                ExceptionType::BadAccess
+                            },
                             SadnessFlavor::DivideByZero => ExceptionType::Arithmetic,
                             SadnessFlavor::Illegal => ExceptionType::BadInstruction,
                             SadnessFlavor::Trap => ExceptionType::Breakpoint,

--- a/crash-handler/tests/shared.rs
+++ b/crash-handler/tests/shared.rs
@@ -40,7 +40,7 @@ pub fn handles_crash(flavor: SadnessFlavor) {
                         let expected = match flavor {
                             SadnessFlavor::Abort => {
                                 assert_eq!(exc.code, 0x10003); // EXC_SOFT_SIGNAL
-                                assert_eq!(exc.subcode.unwrap(), libc::SIGABRT as i64);
+                                assert_eq!(exc.subcode.unwrap(), libc::SIGABRT as _);
 
                                 ExceptionType::Software
                             }

--- a/crash-handler/tests/shared.rs
+++ b/crash-handler/tests/shared.rs
@@ -58,9 +58,10 @@ pub fn handles_crash(flavor: SadnessFlavor) {
                             SadnessFlavor::DivideByZero => ExceptionType::Arithmetic,
                             SadnessFlavor::Illegal => ExceptionType::BadInstruction,
                             SadnessFlavor::Trap => ExceptionType::Breakpoint,
+                            SadnessFlavor::Guard => ExceptionType::Guard,
                         };
 
-                        assert_eq!(exc.kind, expected as i32);
+                        assert_eq!(exc.kind, expected as _);
                     } else if #[cfg(target_os = "windows")] {
                         use ch::ExceptionCode;
 

--- a/deny.toml
+++ b/deny.toml
@@ -41,3 +41,6 @@ skip-tree = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = []
+
+[sources.allow-org]
+github = ["rust-minidump"]

--- a/deny.toml
+++ b/deny.toml
@@ -24,26 +24,6 @@ default = "deny"
 confidence-threshold = 0.8
 exceptions = [{ allow = ["Unicode-DFS-2016"], name = "unicode-ident" }]
 
-# Some crates don't have (easily) machine readable licensing information,
-# adding a clarification entry for it allows you to manually specify the
-# licensing information
-#[[licenses.clarify]]
-# The name of the crate the clarification applies to
-#name = "ring"
-# The optional version constraint for the crate
-#version = "*"
-# The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
-# One or more files in the crate's source used as the "source of truth" for
-# the license expression. If the contents match, the clarification will be used
-# when running the license check, otherwise the clarification will be ignored
-# and the crate will be checked normally, which may produce warnings or errors
-# depending on the rest of your configuration
-#license-files = [
-# Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
-
 [bans]
 multiple-versions = "deny"
 deny = []

--- a/minidumper-test/Cargo.toml
+++ b/minidumper-test/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = "1.0"
 clap = { version = "3.1", features = ["derive"] }
 cfg-if = "1.0"
 crash-handler = { path = "../crash-handler" }
-minidump = "0.11"
-minidump-common = "0.11"
+minidump = "0.12"
+minidump-common = "0.12"
 minidumper = { path = "../minidumper" }
 # This has some crazy dependencies, can enable manually if needed
 #notify-rust = "4.5"

--- a/minidumper-test/src/crash-client.rs
+++ b/minidumper-test/src/crash-client.rs
@@ -108,6 +108,10 @@ fn real_main() -> anyhow::Result<()> {
                 Signal::InvalidParameter => {
                     sadness_generator::raise_invalid_parameter();
                 }
+                #[cfg(target_os = "macos")]
+                Signal::Guard => {
+                    sadness_generator::raise_guard_exception();
+                }
             }
         }
     };

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -475,14 +475,14 @@ pub fn assert_minidump(md_buf: &[u8], signal: Signal) {
                     // We've tried an operation on a guarded file descriptor
                     assert_eq!(kind, errors::ExceptionCodeMacGuardType::GUARD_TYPE_FD);
                     // The guard identifier used when opening the file
-                    assert_eq!(guard_id, 0x1234567890abcdef);
+                    assert_eq!(guard_id, sadness_generator::GUARD_ID);
 
                     // +-------------------+----------------+--------------+
                     // |[63:61] guard type | [60:32] flavor | [31:0] target|
                     // +-------------------+----------------+--------------+
                     assert_eq!(
                         errors::ExceptionCodeMacGuardType::GUARD_TYPE_FD as u8,
-                        ((dbg!(code) >> 61) & 0x7) as u8
+                        ((code >> 61) & 0x7) as u8
                     );
                     assert_eq!(1 /* GUARD_CLOSE */, ((code >> 32) & 0x1fffffff) as u32);
                     // The target is just the file descriptor itself which is kind of pointless

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -432,6 +432,8 @@ pub fn assert_minidump(md_buf: &[u8], signal: Signal) {
                 verify!(CrashReason::MacBadAccessKern(
                     errors::ExceptionCodeMacBadAccessKernType::KERN_INVALID_ADDRESS,
                 ));
+
+                assert_eq!(crash_address, sadness_generator::SEGFAULT_ADDRESS as _);
             }
             Signal::StackOverflow | Signal::StackOverflowCThread => {
                 verify!(CrashReason::MacBadAccessKern(

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -30,6 +30,8 @@ pub enum Signal {
     Purecall,
     #[cfg(windows)]
     InvalidParameter,
+    #[cfg(target_os = "macos")]
+    Guard,
 }
 
 use std::fmt;
@@ -50,6 +52,8 @@ impl fmt::Display for Signal {
             Self::Purecall => "purecall",
             #[cfg(windows)]
             Self::InvalidParameter => "invalid-parameter",
+            #[cfg(target_os = "macos")]
+            Self::Guard => "guard",
         })
     }
 }

--- a/minidumper-test/tests/macos.rs
+++ b/minidumper-test/tests/macos.rs
@@ -1,0 +1,10 @@
+#![cfg(target_os = "macos")]
+
+use minidumper_test::*;
+
+#[test]
+fn guard_simple() {
+    // Note that since the guard exception uses a particular file path and a
+    // guard id, we don't run this threaded
+    run_test(Signal::Guard, 0, false);
+}

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -428,8 +428,6 @@ pub unsafe fn raise_guard_exception() -> ! {
     const GUARD_SOCKET_IPC: u32 = 1 << 2;
     /// Forbid creating a fileport from a guarded fd
     const GUARD_FILEPORT: u32 = 1 << 3;
-    /// Forbid writes on a guarded fd
-    const GUARD_WRITE: u32 = 1 << 4;
 
     let fd = guarded_open_np(
         b"/tmp/sadness-generator-guard.txt\0".as_ptr(),

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -392,6 +392,11 @@ pub unsafe fn raise_invalid_parameter() -> ! {
     std::process::abort()
 }
 
+/// The identifier used when guarding the file resource when raising
+/// an `EXC_GUARD` exception via [`raise_guard_exception`]
+#[cfg(target_os = "macos")]
+pub const GUARD_ID: u64 = 0x1234567890abcdef;
+
 /// [`SadnessFlavor::Guard`]
 ///
 /// # Safety
@@ -410,17 +415,15 @@ pub unsafe fn raise_guard_exception() -> ! {
         ) -> i32;
     }
 
-    const GUARD_ID: u64 = 0x1234567890abcdef;
-
     // https://github.com/apple-oss-distributions/xnu/blob/e7776783b89a353188416a9a346c6cdb4928faad/bsd/sys/guarded.h#L67-L97
 
-    /// Forbid close(2), and the implicit close() that a dup2(2) may do.
+    /// Forbid `close(2)`, and the implicit `close()` that a `dup2(2)` may do.
     /// Forces close-on-fork to be set immutably too.
     const GUARD_CLOSE: u32 = 1 << 0;
-    /// Forbid dup(2), dup2(2), and fcntl(2) subcodes F_DUPFD, F_DUPFD_CLOEXEC
-    /// on a guarded fd. Also forbids open's of a guarded fd via /dev/fd/
+    /// Forbid `dup(2)`, `dup2(2)`, and `fcntl(2)` subcodes `F_DUPFD`, `F_DUPFD_CLOEXEC`
+    /// on a guarded fd. Also forbids open's of a guarded fd via `/dev/fd/`
     /// (an implicit dup.)
-    const GUARD_DUPE: u32 = 1 << 1;
+    const GUARD_DUP: u32 = 1 << 1;
     /// Forbid sending a guarded fd via a socket
     const GUARD_SOCKET_IPC: u32 = 1 << 2;
     /// Forbid creating a fileport from a guarded fd


### PR DESCRIPTION
Adds the `EXC_GUARD` mask so that those exceptions can now be caught in `crash-handler`. This includes adding support for rasing `EXC_GUARD` exceptions from sadness generator.

While testing the minidumps generated from an `EXC_GUARD` I found out that crash-handler was accidentally truncating the code and subcode of the exceptions since I had forgotten `packed(4)` on the structure that receives the exception details from the mach exception port, basically causing all of the minidumps created from a crash-context captured by the crash-handler to be missing information. Fixing that by looking at the code generated for `mig mach_exc.defs` made me also realize why the mach IPC stuff in crash-context was "weird". When receiving messages, one needs to always account for the "trailer" placed at the end by the kernel, so now that code is cleaner as well.

Also improved documentation by linking directly to the xnu sources in github.

Resolves: #34 