### PR TITLE
Change segfault address

### DIFF
--- a/crash-handler/tests/shared.rs
+++ b/crash-handler/tests/shared.rs
@@ -22,11 +22,13 @@ pub fn handles_crash(flavor: SadnessFlavor) {
                                 SadnessFlavor::Bus => Signal::Bus,
                                 SadnessFlavor::DivideByZero => Signal::Fpe,
                                 SadnessFlavor::Illegal => Signal::Illegal,
-                                SadnessFlavor::Segfault | SadnessFlavor::StackOverflow { .. } =>
-                                    Signal::Segv,
-                                    SadnessFlavor::Trap => Signal::Trap,
-                            } as u32
+                                SadnessFlavor::Segfault | SadnessFlavor::StackOverflow { .. } => {
+                                    Signal::Segv
+                                }
+                                SadnessFlavor::Trap => Signal::Trap,
+                            } as u32,
                         );
+
                         //assert_eq!(cc.tid, tid);
 
                         // At least on linux these...aren't set. Which is weird

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -333,6 +333,8 @@ pub fn assert_minidump(md_buf: &[u8], signal: Signal) {
                 verify!(CrashReason::LinuxSigsegv(
                     errors::ExceptionCodeLinuxSigsegvKind::SEGV_MAPERR
                 ));
+
+                //assert_eq!(crash_address, sadness_generator::SEGFAULT_ADDRESS as _);
             }
             Signal::StackOverflow | Signal::StackOverflowCThread => {
                 // Not sure if there is a way to work around this, but on Linux it seems that a stack overflow

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -119,7 +119,7 @@ pub unsafe fn raise_abort() -> ! {
 /// this address can be mapped and writable by the your process in which case a
 /// crash may not occur
 #[cfg(target_pointer_width = "64")]
-pub const SEGFAULT_ADDRESS: u64 = u64::MAX - ((u32::MAX >> 1) as u64) + 0x42;
+pub const SEGFAULT_ADDRESS: u64 = u32::MAX as u64 + 0x42;
 #[cfg(target_pointer_width = "32")]
 pub const SEGFAULT_ADDRESS: u32 = 0x42;
 


### PR DESCRIPTION
The segfault address in sadness-generator was [non-canonical](https://en.wikipedia.org/wiki/X86-64#Canonical_form_addresses) so now it is canonical, but still larger than `u32::MAX` to ensure 64-bit addresses are correctly handled.