### PR TITLE
WIP add a bunch more forms of sadness to the crash suite

### DIFF
--- a/crash-handler/tests/shared.rs
+++ b/crash-handler/tests/shared.rs
@@ -72,7 +72,7 @@ pub fn handles_crash(flavor: SadnessFlavor) {
                             SadnessFlavor::Illegal => ExceptionCode::Illegal,
                             SadnessFlavor::InvalidParameter => ExceptionCode::InvalidParameter,
                             SadnessFlavor::Purecall => ExceptionCode::Purecall,
-                            SadnessFlavor::Segfault => ExceptionCode::Segv,
+                            SadnessFlavor::Segfault | SadnessFlavor::SegfaultNonCanonical => ExceptionCode::Segv,
                             SadnessFlavor::StackOverflow { .. }=> ExceptionCode::StackOverflow,
                             SadnessFlavor::Trap => ExceptionCode::Trap,
                         };


### PR DESCRIPTION
Not sure if everything should go into sadness generator or if it wants to be purely about signals.

The expectations for the new "high level rust" failures are currently stubbed out pending me figuring out what they should be, if anything.

Ideally this PR would also include adding support for setting up a panic handler that invokes crash handler. Panic handlers run regardless of the panic=abort setting, so they can be used to reliably log panics. In principle they could/should take care to populate the [MinidumpAssertion](https://docs.rs/minidump/latest/minidump/struct.MinidumpAssertion.html) stream, which is basically designed for this kind of thing.

However I'm not sure if we want this to be an intrinsic feature of crash-handler or something that we tell users how to do manually. My inclincation is the former.