### PR TITLE
diskwrite example: add logging

### DIFF
--- a/minidumper/Cargo.toml
+++ b/minidumper/Cargo.toml
@@ -52,6 +52,7 @@ features = [
 [dev-dependencies]
 # Diskwrite example
 crash-handler = { path = "../crash-handler" }
+pretty_env_logger = "0.4.0"
 # uuid generation
 uuid = { version = "1.0", features = ["v4"] }
 backtrace = "0.3"

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -3,6 +3,7 @@ const SOCKET_NAME: &str = "minidumper-disk-example";
 use minidumper::{Client, Server};
 
 fn main() {
+    pretty_env_logger::init();
     if std::env::args().any(|a| a == "--server") {
         let mut server = Server::with_name(SOCKET_NAME).expect("failed to create server");
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The `diskwrite` example includes logging statements, but no logger to process them. This adds `pretty_env_logger` to the dev dependencies of `minidumper` and initializes it in `main`.