### PR TITLE
diskwrite example: make directory handling more robust

### DIFF
--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -18,13 +18,15 @@ fn main() {
             ) -> Result<(std::fs::File, std::path::PathBuf), std::io::Error> {
                 let uuid = uuid::Uuid::new_v4();
 
-                let dir_path = std::path::PathBuf::from("dumps");
-                let file_path = dir_path.join(format!("{uuid}.dmp"));
-                if !dir_path.try_exists()? {
-                    std::fs::create_dir(dir_path)?;
+                let dump_path = std::path::PathBuf::from(format!("dumps/{uuid}.dmp"));
+
+                if let Some(dir) = dump_path.parent() {
+                    if !dir.try_exists()? {
+                        std::fs::create_dir_all(dir)?;
+                    }
                 }
-                let file = std::fs::File::create(&file_path)?;
-                Ok((file, file_path))
+                let file = std::fs::File::create(&dump_path)?;
+                Ok((file, dump_path))
             }
 
             /// Called when a crash has been fully written as a minidump to the provided
@@ -50,8 +52,7 @@ fn main() {
 
             fn on_message(&self, kind: u32, buffer: Vec<u8>) {
                 log::info!(
-                    "kind: {}, message: {}",
-                    kind,
+                    "kind: {kind}, message: {}",
                     String::from_utf8(buffer).unwrap()
                 );
             }

--- a/minidumper/examples/diskwrite.rs
+++ b/minidumper/examples/diskwrite.rs
@@ -18,8 +18,13 @@ fn main() {
             ) -> Result<(std::fs::File, std::path::PathBuf), std::io::Error> {
                 let uuid = uuid::Uuid::new_v4();
 
-                let pb = std::path::PathBuf::from(format!("dumps/{}.dmp", uuid));
-                Ok((std::fs::File::create(&pb)?, pb))
+                let dir_path = std::path::PathBuf::from("dumps");
+                let file_path = dir_path.join(format!("{uuid}.dmp"));
+                if !dir_path.try_exists()? {
+                    std::fs::create_dir(dir_path)?;
+                }
+                let file = std::fs::File::create(&file_path)?;
+                Ok((file, file_path))
             }
 
             /// Called when a crash has been fully written as a minidump to the provided


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
This changes the `diskwrite` examples so that the `dumps` directory is created if it doesn't exist.