### PR TITLE
Retry if poll returns Interrupted

### DIFF
--- a/minidumper/src/ipc/server.rs
+++ b/minidumper/src/ipc/server.rs
@@ -1,7 +1,7 @@
-use std::io::ErrorKind;
 use super::{Connection, Header, Listener, SocketName};
 use crate::{Error, LoopAction};
 use polling::{Event, Poller};
+use std::io::ErrorKind;
 use std::time::{Duration, Instant};
 
 /// Server side of the connection, which runs in the monitor process that is


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
Instead of stopping `run` on interrupts,  retry the Poll. In the dependent libs epoll is used, [epoll_wait will return EINTR](https://man7.org/linux/man-pages/man2/epoll_wait.2.html) on an interrupt (in which case we want to retry) or a timeout. In the second case we can just check if our timeout is passed, which is not an error case, and continue along.

