### PR TITLE
Add `RtlCaptureContext` replacement

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -56,6 +56,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   publish-check:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -56,7 +56,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   publish-check:

--- a/crash-context/Cargo.toml
+++ b/crash-context/Cargo.toml
@@ -26,3 +26,8 @@ libc = "0.2"
 [target.'cfg(target_os = "macos")'.dependencies]
 # provides bindings to mach specifics
 mach2 = "0.4"
+
+# Provides bindings to Win32
+[target.'cfg(target_os = "windows")'.dependencies.winapi]
+version = "0.3"
+features = ["winnt"]

--- a/crash-context/src/windows.rs
+++ b/crash-context/src/windows.rs
@@ -1,3 +1,5 @@
+pub mod ffi;
+
 /// Full Windows crash context
 pub struct CrashContext {
     /// The information on the exception.

--- a/crash-context/src/windows.rs
+++ b/crash-context/src/windows.rs
@@ -3,15 +3,12 @@ pub struct CrashContext {
     /// The information on the exception.
     ///
     /// Note that this is a pointer into the actual memory of the crashed process,
-    /// and is a pointer to an [EXCEPTION_POINTERS](https://docs.rs/windows-sys/0.35.0/windows_sys/Win32/System/Diagnostics/Debug/struct.EXCEPTION_POINTERS.html)
-    ///
-    /// We intentionally don't use `windows-sys` here as the type information is
-    /// completely lost when crossing process boundaries anyways
-    pub exception_pointers: *const std::ffi::c_void,
+    /// and is a pointer to an [EXCEPTION_POINTERS](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-exception_pointers)
+    pub exception_pointers: *const ffi::EXCEPTION_POINTERS,
     /// The top level exception code from the exception_pointers. This is provided
     /// so that external processes don't need to use `ReadProcessMemory` to inspect
     /// the exception code
-    pub exception_code: i32,
+    pub exception_code: u32,
     /// The pid of the process that crashed
     pub process_id: u32,
     /// The thread id on which the exception occurred

--- a/crash-context/src/windows/ffi.rs
+++ b/crash-context/src/windows/ffi.rs
@@ -1,0 +1,49 @@
+//! Custom bindings to `CONTEXT` and some structures that relate to it, to both
+//! deal with bugs in bindings, as well as not be dependent particularly on
+//! `windows-sys` due the massive amount of version churn that crate introduces.
+//!
+//! Both [`winapi`](https://docs.rs/winapi/latest/winapi/) and
+//! [`windows-sys`](https://docs.rs/windows-sys/latest/windows_sys/) have
+//! incorrect bindings with regards to `CONTEXT` and its related structures.
+//! These structures **must** be aligned to 16 bytes, but [are not](https://github.com/microsoft/win32metadata/issues/1044).
+
+#![allow(non_snake_case)]
+
+extern "C" {
+    /// Reimplementation of [`RtlCaptureContext`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-rtlcapturecontext)
+    ///
+    /// As noted above, the structures from `winapi` and `windows-sys` have
+    /// incorrect alignment.
+    ///
+    /// In addition, `RtlCaptureContext` only captures the state of the integer
+    /// registers, while this implementation additionally captures floating point
+    /// and vector state.
+    ///
+    /// The implementation is ported from Crashpad.
+    ///
+    /// - [x86](https://github.com/chromium/crashpad/blob/f742c1aa4aff1834dc55e97895f8cdfdfc945a21/util/misc/capture_context_win.asm)
+    /// - [aarch64](https://github.com/chromium/crashpad/blob/f742c1aa4aff1834dc55e97895f8cdfdfc945a21/util/misc/capture_context_win_arm64.asm)
+    pub fn capture_context(ctx: *mut CONTEXT);
+}
+
+pub use winapi::um::winnt::EXCEPTION_RECORD;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        mod x86_64;
+        pub use x86_64::*;
+    } else if #[cfg(target_arch = "x86")] {
+        compile_error!("Please file an issue if you care about this target");
+        //mod x86;
+    } else if #[cfg(target_arch = "aarch64")] {
+        mod aarch64;
+        pub use aarch64::*;
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct EXCEPTION_POINTERS {
+    pub ExceptionRecord: *mut EXCEPTION_RECORD,
+    pub ContextRecord: *mut CONTEXT,
+}

--- a/crash-context/src/windows/ffi/aarch64.rs
+++ b/crash-context/src/windows/ffi/aarch64.rs
@@ -1,0 +1,143 @@
+// Copyright 2019 The Crashpad Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Copy, Clone)]
+// Note this is intentionally using natural alignment
+#[repr(C)]
+pub union ARM64_NT_NEON128 {
+    pub Anonymous: ARM64_NT_NEON128_0,
+    pub D: [f64; 2],
+    pub S: [f32; 4],
+    pub H: [u16; 8],
+    pub B: [u8; 16],
+}
+
+#[derive(Copy, Clone)]
+// Note this is intentionally using natural alignment
+#[repr(C)]
+pub struct ARM64_NT_NEON128_0 {
+    pub Low: u64,
+    pub High: i64,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub struct CONTEXT {
+    pub ContextFlags: u32,
+    pub Cpsr: u32,
+    pub Anonymous: CONTEXT_0,
+    pub Sp: u64,
+    pub Pc: u64,
+    pub V: [ARM64_NT_NEON128; 32],
+    pub Fpcr: u32,
+    pub Fpsr: u32,
+    pub Bcr: [u32; 8],
+    pub Bvr: [u64; 8],
+    pub Wcr: [u32; 2],
+    pub Wvr: [u64; 2],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub union CONTEXT_0 {
+    pub Anonymous: CONTEXT_0_0,
+    pub X: [u64; 31],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub struct CONTEXT_0_0 {
+    pub X0: u64,
+    pub X1: u64,
+    pub X2: u64,
+    pub X3: u64,
+    pub X4: u64,
+    pub X5: u64,
+    pub X6: u64,
+    pub X7: u64,
+    pub X8: u64,
+    pub X9: u64,
+    pub X10: u64,
+    pub X11: u64,
+    pub X12: u64,
+    pub X13: u64,
+    pub X14: u64,
+    pub X15: u64,
+    pub X16: u64,
+    pub X17: u64,
+    pub X18: u64,
+    pub X19: u64,
+    pub X20: u64,
+    pub X21: u64,
+    pub X22: u64,
+    pub X23: u64,
+    pub X24: u64,
+    pub X25: u64,
+    pub X26: u64,
+    pub X27: u64,
+    pub X28: u64,
+    pub Fp: u64,
+    pub Lr: u64,
+}
+
+std::arch::global_asm! {
+  ".text",
+  ".global capture_context",
+"capture_context:",
+  // Save general purpose registers in context.regs[i].
+  // The original x0 can't be recovered.
+  "stp x0, x1, [x0, #0x008]",
+  "stp x2, x3, [x0, #0x018]",
+  "stp x4, x5, [x0, #0x028]",
+  "stp x6, x7, [x0, #0x038]",
+  "stp x8, x9, [x0, #0x048]",
+  "stp x10, x11, [x0, #0x058]",
+  "stp x12, x13, [x0, #0x068]",
+  "stp x14, x15, [x0, #0x078]",
+  "stp x16, x17, [x0, #0x088]",
+  "stp x18, x19, [x0, #0x098]",
+  "stp x20, x21, [x0, #0x0a8]",
+  "stp x22, x23, [x0, #0x0b8]",
+  "stp x24, x25, [x0, #0x0c8]",
+  "stp x26, x27, [x0, #0x0d8]",
+  "stp x28, x29, [x0, #0x0e8]",
+
+  // The original LR can't be recovered.
+  "str LR, [x0, #0x0f8]",
+
+  // Use x1 as a scratch register.
+  "mov x1, SP",
+  // context.sp
+  "str x1, [x0, #0x100]",
+
+  // The link register holds the return address for this function.
+  // context.pc
+  "str LR, [x0, #0x108]",
+
+  // pstate should hold SPSR but NZCV are the only bits we know about.
+  "mrs x1, NZCV",
+
+  // Enable Control flags, such as CONTEXT_ARM64, CONTEXT_CONTROL,
+  // CONTEXT_INTEGER
+  "ldr w1, =0x00400003",
+
+  // Set ControlFlags /0x000/ and pstate /0x004/ at the same time.
+  "str x1, [x0, #0x000]",
+
+  // Restore x1 from the saved context.
+  "ldr x1, [x0, #0x010]",
+
+  // TODO(https://crashpad.chromium.org/bug/300): save floating-point registers
+  "ret",
+}

--- a/crash-context/src/windows/ffi/x86_64.rs
+++ b/crash-context/src/windows/ffi/x86_64.rs
@@ -1,0 +1,251 @@
+// Copyright 2015 The Crashpad Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub struct M128A {
+    pub Low: u64,
+    pub High: i64,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub struct XSAVE_FORMAT {
+    pub ControlWord: u16,
+    pub StatusWord: u16,
+    pub TagWord: u8,
+    pub Reserved1: u8,
+    pub ErrorOpcode: u16,
+    pub ErrorOffset: u32,
+    pub ErrorSelector: u16,
+    pub Reserved2: u16,
+    pub DataOffset: u32,
+    pub DataSelector: u16,
+    pub Reserved3: u16,
+    pub MxCsr: u32,
+    pub MxCsr_Mask: u32,
+    pub FloatRegisters: [M128A; 8],
+    pub XmmRegisters: [M128A; 16],
+    pub Reserved4: [u8; 96],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub struct CONTEXT {
+    pub P1Home: u64,
+    pub P2Home: u64,
+    pub P3Home: u64,
+    pub P4Home: u64,
+    pub P5Home: u64,
+    pub P6Home: u64,
+    pub ContextFlags: u32,
+    pub MxCsr: u32,
+    pub SegCs: u16,
+    pub SegDs: u16,
+    pub SegEs: u16,
+    pub SegFs: u16,
+    pub SegGs: u16,
+    pub SegSs: u16,
+    pub EFlags: u32,
+    pub Dr0: u64,
+    pub Dr1: u64,
+    pub Dr2: u64,
+    pub Dr3: u64,
+    pub Dr6: u64,
+    pub Dr7: u64,
+    pub Rax: u64,
+    pub Rcx: u64,
+    pub Rdx: u64,
+    pub Rbx: u64,
+    pub Rsp: u64,
+    pub Rbp: u64,
+    pub Rsi: u64,
+    pub Rdi: u64,
+    pub R8: u64,
+    pub R9: u64,
+    pub R10: u64,
+    pub R11: u64,
+    pub R12: u64,
+    pub R13: u64,
+    pub R14: u64,
+    pub R15: u64,
+    pub Rip: u64,
+    pub Anonymous: CONTEXT_0,
+    pub VectorRegister: [M128A; 26],
+    pub VectorControl: u64,
+    pub DebugControl: u64,
+    pub LastBranchToRip: u64,
+    pub LastBranchFromRip: u64,
+    pub LastExceptionToRip: u64,
+    pub LastExceptionFromRip: u64,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub union CONTEXT_0 {
+    pub FltSave: XSAVE_FORMAT,
+    pub Anonymous: CONTEXT_0_0,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub struct CONTEXT_0_0 {
+    pub Header: [M128A; 2],
+    pub Legacy: [M128A; 8],
+    pub Xmm0: M128A,
+    pub Xmm1: M128A,
+    pub Xmm2: M128A,
+    pub Xmm3: M128A,
+    pub Xmm4: M128A,
+    pub Xmm5: M128A,
+    pub Xmm6: M128A,
+    pub Xmm7: M128A,
+    pub Xmm8: M128A,
+    pub Xmm9: M128A,
+    pub Xmm10: M128A,
+    pub Xmm11: M128A,
+    pub Xmm12: M128A,
+    pub Xmm13: M128A,
+    pub Xmm14: M128A,
+    pub Xmm15: M128A,
+}
+
+std::arch::global_asm! {
+  ".text",
+  ".global capture_context",
+"capture_context:",
+  ".seh_proc capture_context",
+  "push %rbp",
+  ".seh_pushreg %rbp",
+  "movq %rsp, %rbp",
+  ".seh_setframe %rbp, 0",
+
+  // Note that 16-byte stack alignment is not maintained because this function
+  // does not call out to any other.
+
+  // pushfq first, because some instructions affect rflags. rflags will be in [rbp-8].
+  "pushfq",
+  ".seh_stackalloc 8",
+  ".seh_endprologue",
+
+  "movl $0x10000f, 0x30(%rcx)",  // ContextFlags
+
+  // General-purpose registers whose values haven’t changed can be captured directly.
+  "movq %rax, 0x78(%rcx)",       // Rax
+  "movq %rdx, 0x88(%rcx)",       // Rdx
+  "movq %rbx, 0x90(%rcx)",       // Rbx
+  "movq %rsi, 0xa8(%rcx)",       // Rsi
+  "movq %rdi, 0xb0(%rcx)",       // Rdi
+  "movq %r8, 0xb8(%rcx)",        // R8
+  "movq %r9, 0xc0(%rcx)",        // R9
+  "movq %r10, 0xc8(%rcx)",       // R10
+  "movq %r11, 0xd0(%rcx)",       // R11
+  "movq %r12, 0xd8(%rcx)",       // R12
+  "movq %r13, 0xe0(%rcx)",       // R13
+  "movq %r14, 0xe8(%rcx)",       // R14
+  "movq %r15, 0xf0(%rcx)",       // R15
+
+  // Because of the calling convention, there’s no way to recover the value of
+  // the caller’s rcx as it existed prior to calling this function. This
+  // function captures a snapshot of the register state at its return, which
+  // involves rcx containing a pointer to its first argument.
+  "movq %rcx, 0x80(%rcx)",       // Rcx
+
+  // Now that the original value of rax has been saved, it can be repurposed to
+  // hold other registers’ values.
+
+  // Save mxcsr. This is duplicated in context->FltSave.MxCsr, saved by fxsave
+  // below.
+  "stmxcsr 0x34(%rcx)",         // MxCsr
+
+  // Segment registers.
+  "movw %cs, 0x38(%rcx)",        // SegCs
+  "movw %ds, 0x3a(%rcx)",        // SegDs
+  "movw %es, 0x3c(%rcx)",        // SegEs
+  "movw %fs, 0x3e(%rcx)",        // SegFs
+  "movw %gs, 0x40(%rcx)",        // SegGs
+  "movw %ss, 0x42(%rcx)",        // SegSs
+
+  // The original rflags was saved on the stack above. Note that the CONTEXT
+  // structure only stores eflags, the low 32 bits. The high 32 bits in rflags
+  // are reserved.
+  "movq -8(%rbp), %rax",
+  "mov %eax, 0x44(%rcx)",       // EFlags
+
+  // rsp was saved in rbp in this function’s prologue, but the caller’s rsp is
+  // 16 more than this value: 8 for the original rbp saved on the stack in this
+  // function’s prologue, and 8 for the return address saved on the stack by the
+  // call instruction that reached this function.
+  "leaq 16(%rbp), %rax",
+  "movq %rax, 0x98(%rcx)",
+
+  // The original rbp was saved on the stack in this function’s prologue.
+  "movq %rbp, %rax",
+  "movq %rax, 0xa0(%rcx)",
+
+  // rip can’t be accessed directly, but the return address saved on the stack by
+  // the call instruction that reached this function can be used.
+  "movq 8(%rbp), %rax",
+  "movq %rax, 0xf8(%rcx)",
+
+  // Zero out the fxsave area before performing the fxsave. Some of the fxsave
+  // area may not be written by fxsave, and some is definitely not written by
+  // fxsave. This also zeroes out the rest of the CONTEXT structure to its end,
+  // including the unused VectorRegister and VectorControl fields, and the debug
+  // control register fields.
+  "movq %rcx, %rbx",
+  "cld",
+  "leaq 0x100(%rcx), %rdi",
+  "xor %rax, %rax",
+  "movq $122, %rcx",
+  "rep stosq",
+  "movq %rbx, %rcx",
+
+  // Save the floating point (including SSE) state. The CONTEXT structure is
+  // declared as 16-byte-aligned, which is correct for this operation.
+  "fxsave 0x100(%rcx)",
+
+  // TODO: AVX/xsave support. https://crashpad.chromium.org/bug/58
+
+  // The register parameter home address fields aren’t used, so zero them out.
+  "movq $0, 0x0(%rcx)",
+  "movq $0, 0x8(%rcx)",
+  "movq $0, 0x10(%rcx)",
+  "movq $0, 0x18(%rcx)",
+  "movq $0, 0x20(%rcx)",
+
+  // The debug registers can’t be read from user code, so zero them out in the
+  // CONTEXT structure. context->ContextFlags doesn’t indicate that they are
+  // present.
+  "movq $0, 0x48(%rcx)",
+  "movq $0, 0x50(%rcx)",
+  "movq $0, 0x58(%rcx)",
+  "movq $0, 0x60(%rcx)",
+  "movq $0, 0x68(%rcx)",
+  "movq $0, 0x70(%rcx)",
+  "movq $0, 0x78(%rcx)",
+
+  // Clean up by restoring clobbered registers, even those considered volatile by
+  // the ABI, so that the captured context represents the state at this
+  // function’s exit.
+  "movq 0x78(%rcx), %rax",
+  "movq 0x90(%rcx), %rbx",
+  "movq 0xb0(%rcx), %rdi",
+  "popfq",
+
+  "popq %rbp",
+  "ret",
+  ".seh_endproc",
+  options(att_syntax)
+}

--- a/crash-handler/Cargo.toml
+++ b/crash-handler/Cargo.toml
@@ -28,15 +28,6 @@ libc = "0.2"
 # Nicer sync primitives
 parking_lot = "0.12"
 
-[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.42" # Keep aligned with parking_lot & minidump-writer
-features = [
-    "Win32_Foundation",
-    "Win32_System_Diagnostics_Debug",
-    "Win32_System_Kernel",
-    "Win32_System_Threading",
-]
-
 [target.'cfg(target_os = "macos")'.dependencies]
 # Bindings to MacOS specific APIs that are used. Note we don't use the `mach`
 # crate as it is unmaintained

--- a/crash-handler/Cargo.toml
+++ b/crash-handler/Cargo.toml
@@ -22,7 +22,7 @@ debug-print = []
 cfg-if = "1.0"
 # Definition of a portable crash-context that can be shared between various
 # crates
-crash-context = "0.4"
+crash-context = { version = "0.4", path = "../crash-context" }
 # Wrapper around libc
 libc = "0.2"
 # Nicer sync primitives

--- a/crash-handler/src/lib.rs
+++ b/crash-handler/src/lib.rs
@@ -51,7 +51,13 @@ pub use crash_context::CrashContext;
 pub enum CrashEventResult {
     /// The event was handled in some way
     Handled(bool),
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(all(
+        not(target_os = "macos"),
+        any(
+            target_os = "linux",
+            all(target_os = "windows", target_arch = "x86_64")
+        )
+    ))]
     /// The handler wishes to jump somewhere else, presumably to return
     /// execution and skip the code that caused the exception
     Jump {
@@ -139,7 +145,10 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "windows")] {
         mod windows;
 
-        pub use windows::{CrashHandler, ExceptionCode, jmp};
+        #[cfg(target_arch = "x86_64")]
+        pub use windows::jmp;
+
+        pub use windows::{CrashHandler, ExceptionCode};
     } else if #[cfg(target_os = "macos")] {
         mod mac;
 

--- a/crash-handler/src/windows.rs
+++ b/crash-handler/src/windows.rs
@@ -12,7 +12,7 @@ use windows_sys::Win32::Foundation as found;
 /// as eg. a distinction is made between a divide by zero between integers and
 /// floats.
 #[derive(Copy, Clone)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum ExceptionCode {
     Fpe = found::EXCEPTION_INT_DIVIDE_BY_ZERO,
     Illegal = found::EXCEPTION_ILLEGAL_INSTRUCTION,
@@ -46,9 +46,9 @@ impl CrashHandler {
         state::detach();
     }
 
-    // Sends the specified user exception
-    #[allow(clippy::unused_self)]
-    pub fn simulate_exception(&self, exception_code: Option<i32>) -> crate::CrashEventResult {
+    /// Creates an exception with the specified exception code that is passed
+    /// through the user provided callback.
+    pub fn simulate_exception(&self, exception_code: Option<u32>) -> crate::CrashEventResult {
         // Normally this would be an unsafe function, since this unsafe encompasses
         // the entirety of the body, however the user is really not required to
         // uphold any guarantees on their end, so no real need to declare the

--- a/crash-handler/src/windows/jmp.rs
+++ b/crash-handler/src/windows/jmp.rs
@@ -1,9 +1,30 @@
+// The MIT License (MIT)
+//
+// Copyright © 2016 Franklin "Snaipe" Mathieu <http://snai.pe/>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 //! Provides an implementation of [`setjmp`] and [`longjmp`], as unfortunately the
 //! implementation in MSVCRT actually unwinds the stack
 
 #![cfg(target_arch = "x86_64")]
 
-// Original code from: https://github.com/Snaipe/BoxFort/blob/master/src/asm/setjmp-x86_64.asm
 std::arch::global_asm! {
     ".text",
     ".global ehsetjmp",

--- a/crash-handler/src/windows/signal.rs
+++ b/crash-handler/src/windows/signal.rs
@@ -1,0 +1,36 @@
+//! Windows doesn't have an exception for process aborts, so we hook `SIGABRT`
+
+/// Installs our `SIGABRT` handler, returning any previously registered handler,
+/// which should be restored later
+///
+/// # Safety
+///
+/// Performs syscalls
+pub(crate) unsafe fn install_abort_handler() -> Result<libc::sighandler_t, std::io::Error> {
+    // It would be nice to use sigaction here since it's better, but it isn't
+    // supported on Windows :p
+    let old_handler = libc::signal(libc::SIGABRT, signal_handler as usize);
+    if old_handler != usize::MAX {
+        Ok(old_handler)
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+/// Restores the action for `SIGABRT` to the specified handler
+///
+/// # Safety
+///
+/// Performs syscalls
+#[inline]
+pub(crate) unsafe fn restore_abort_handler(handler: libc::sighandler_t) {
+    libc::signal(libc::SIGABRT, handler);
+}
+
+unsafe extern "C" fn signal_handler(signal: i32, _subcode: i32) {
+    // Sanity check
+    assert_eq!(signal, libc::SIGABRT);
+
+    // https://github.com/chromium/crashpad/blob/fca8871ca3fb721d3afab370ca790122f9333bfd/client/crashpad_client_win.cc#L197
+    super::state::simulate_exception(Some(super::ExceptionCode::Abort as u32));
+}

--- a/crash-handler/src/windows/state.rs
+++ b/crash-handler/src/windows/state.rs
@@ -116,6 +116,38 @@ pub(super) fn detach() {
     lock.take();
 }
 
+pub(super) unsafe fn simulate_exception(exception_code: Option<u32>) -> crate::CrashEventResult {
+    let lock = HANDLER.lock();
+    if let Some(handler) = &*lock {
+        let mut exception_record: ffi::EXCEPTION_RECORD = std::mem::zeroed();
+        let mut exception_context = std::mem::MaybeUninit::zeroed();
+
+        ffi::capture_context(exception_context.as_mut_ptr());
+
+        let mut exception_context = exception_context.assume_init();
+
+        let exception_ptrs = ffi::EXCEPTION_POINTERS {
+            ExceptionRecord: &mut exception_record,
+            ContextRecord: &mut exception_context,
+        };
+
+        // https://github.com/chromium/crashpad/blob/fca8871ca3fb721d3afab370ca790122f9333bfd/util/win/exception_codes.h#L32
+        let exception_code = exception_code.unwrap_or(ExceptionCode::User as u32);
+        exception_record.ExceptionCode = exception_code;
+
+        let cc = crash_context::CrashContext {
+            exception_pointers: (&exception_ptrs as *const ffi::EXCEPTION_POINTERS).cast(),
+            process_id: std::process::id(),
+            thread_id: GetCurrentThreadId(),
+            exception_code,
+        };
+
+        handler.user_handler.on_crash(&cc)
+    } else {
+        crate::CrashEventResult::Handled(false)
+    }
+}
+
 /// While handling any exceptions, especially when calling user code, we restore
 /// and previously registered handlers
 /// Note this keeps the `HANDLER` lock for the duration of the scope
@@ -175,7 +207,7 @@ use crate::CrashEventResult;
 pub(super) unsafe extern "system" fn handle_exception(
     except_info: *const EXCEPTION_POINTERS,
 ) -> i32 {
-    let jump = {
+    let _jump = {
         let lock = HANDLER.lock();
         if let Some(current_handler) = AutoHandler::new(lock) {
             let code = (*(*except_info).ExceptionRecord).ExceptionCode;
@@ -209,6 +241,7 @@ pub(super) unsafe extern "system" fn handle_exception(
                         EXCEPTION_CONTINUE_SEARCH
                     };
                 }
+                #[cfg(target_arch = "x86_64")]
                 CrashEventResult::Jump { jmp_buf, value } => (jmp_buf, value),
             }
         } else {
@@ -216,7 +249,8 @@ pub(super) unsafe extern "system" fn handle_exception(
         }
     };
 
-    super::jmp::longjmp(jump.0, jump.1);
+    #[cfg(target_arch = "x86_64")]
+    super::jmp::longjmp(_jump.0, _jump.1);
 }
 
 /// Handler for invalid parameters to CRT functions, this is not an exception so
@@ -236,7 +270,7 @@ unsafe extern "C" fn handle_invalid_parameter(
     line: u32,
     reserved: usize,
 ) {
-    let jump = {
+    let _jump = {
         let lock = HANDLER.lock();
         if let Some(current_handler) = AutoHandler::new(lock) {
             // Make up an exception record for the current thread and CPU context
@@ -255,13 +289,14 @@ unsafe extern "C" fn handle_invalid_parameter(
                 ContextRecord: &mut exception_context,
             };
 
-            exception_record.ExceptionCode = STATUS_INVALID_PARAMETER;
+            let exception_code = ExceptionCode::InvalidParameter as u32;
+            exception_record.ExceptionCode = exception_code;
 
             match current_handler.user_handler.on_crash(&crate::CrashContext {
                 exception_pointers: (&exception_ptrs as *const EXCEPTION_POINTERS).cast(),
                 process_id: std::process::id(),
                 thread_id: GetCurrentThreadId(),
-                exception_code: STATUS_INVALID_PARAMETER,
+                exception_code,
             }) {
                 CrashEventResult::Handled(true) => return,
                 CrashEventResult::Handled(false) => {
@@ -292,6 +327,7 @@ unsafe extern "C" fn handle_invalid_parameter(
                     // the behavior of "swallowing" exceptions.
                     std::process::exit(0);
                 }
+                #[cfg(target_arch = "x86_64")]
                 CrashEventResult::Jump { jmp_buf, value } => (jmp_buf, value),
             }
         } else {
@@ -299,14 +335,15 @@ unsafe extern "C" fn handle_invalid_parameter(
         }
     };
 
-    super::jmp::longjmp(jump.0, jump.1);
+    #[cfg(target_arch = "x86_64")]
+    super::jmp::longjmp(_jump.0, _jump.1);
 }
 
 /// Handler for pure virtual function calls, this is not an exception so the
 /// context (shouldn't be) isn't compromised
 #[no_mangle]
 unsafe extern "C" fn handle_pure_virtual_call() {
-    let jump = {
+    let _jump = {
         let lock = HANDLER.lock();
         if let Some(current_handler) = AutoHandler::new(lock) {
             // Make up an exception record for the current thread and CPU context
@@ -325,13 +362,14 @@ unsafe extern "C" fn handle_pure_virtual_call() {
                 ContextRecord: &mut exception_context,
             };
 
-            exception_record.ExceptionCode = STATUS_NONCONTINUABLE_EXCEPTION;
+            let exception_code = ExceptionCode::Purecall as u32;
+            exception_record.ExceptionCode = exception_code;
 
             match current_handler.user_handler.on_crash(&crate::CrashContext {
                 exception_pointers: (&exception_ptrs as *const EXCEPTION_POINTERS).cast(),
                 process_id: std::process::id(),
                 thread_id: GetCurrentThreadId(),
-                exception_code: STATUS_NONCONTINUABLE_EXCEPTION,
+                exception_code,
             }) {
                 CrashEventResult::Handled(true) => {
                     // The handler either took care of the invalid parameter problem itself,
@@ -350,6 +388,7 @@ unsafe extern "C" fn handle_pure_virtual_call() {
                     // This will just throw up an assertion dialog.
                     return;
                 }
+                #[cfg(target_arch = "x86_64")]
                 CrashEventResult::Jump { jmp_buf, value } => (jmp_buf, value),
             }
         } else {
@@ -357,5 +396,6 @@ unsafe extern "C" fn handle_pure_virtual_call() {
         }
     };
 
-    super::jmp::longjmp(jump.0, jump.1);
+    #[cfg(target_arch = "x86_64")]
+    super::jmp::longjmp(_jump.0, _jump.1);
 }

--- a/crash-handler/tests/shared.rs
+++ b/crash-handler/tests/shared.rs
@@ -78,9 +78,9 @@ pub fn handles_crash(flavor: SadnessFlavor) {
                         };
 
                         assert_eq!(
-                            cc.exception_code, ec as i32,
+                            cc.exception_code, ec as u32,
                             "0x{:x} != 0x{:x}",
-                            cc.exception_code, ec as i32
+                            cc.exception_code, ec as u32
                         );
                     }
                 }

--- a/minidumper-test/src/lib.rs
+++ b/minidumper-test/src/lib.rs
@@ -196,7 +196,7 @@ pub fn run_client(id: &str, signal: Signal, use_thread: bool) {
     let mut cmd = std::process::Command::new(&cmd_path);
     cmd.stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-    cmd.args(&["--id", id, "--signal", &signal.to_string()]);
+    cmd.args(["--id", id, "--signal", &signal.to_string()]);
     if use_thread {
         cmd.arg("--use-thread");
     }

--- a/minidumper/src/errors.rs
+++ b/minidumper/src/errors.rs
@@ -23,7 +23,7 @@ pub enum Error {
     /// An error occurred during minidump generation
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[error(transparent)]
-    Writer(#[from] minidump_writer::errors::WriterError),
+    Writer(Box<minidump_writer::errors::WriterError>),
     /// An error occurred during minidump generation
     #[cfg(target_os = "windows")]
     #[error(transparent)]
@@ -38,4 +38,11 @@ pub enum Error {
     Scroll(#[from] scroll::Error),
     #[error("protocol error occurred: {0}")]
     ProtocolError(&'static str),
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl From<minidump_writer::errors::WriterError> for Error {
+    fn from(we: minidump_writer::errors::WriterError) -> Self {
+        Self::Writer(Box::new(we))
+    }
 }


### PR DESCRIPTION
This adds a replacement for [`RtlCaptureContext`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-rtlcapturecontext) ported from Crashpad. The implementation is put here since this crate is used by both `crash-handling` in this repo, as well as `minidump-writer`, and unfortunately the bindings for both `winapi` and `windows-sys` are currently...broken. Neither of them properly [align](https://github.com/microsoft/win32metadata/issues/1044) the `CONTEXT` structures on x86_64/aarch64, which can cause [crashes](https://github.com/rust-minidump/minidump-writer/issues/63) and is just generally uhhh, not good. Since we already have replacments for getcontext on Linux it made sense to put it here. Additionally, unlike `RtlCaptureContext`, the x86_64 (though not aarch64) implementation captures floating point and vector state as well.