### PR TITLE
Add abort handling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,6 @@
 # add the below section to `.cargo/config.toml`
+# [target.x86_64-pc-windows-msvc]
+# linker = "lld-link"
 
 [target.'cfg(all())']
 rustflags = [

--- a/crash-handler/Cargo.toml
+++ b/crash-handler/Cargo.toml
@@ -22,7 +22,7 @@ debug-print = []
 cfg-if = "1.0"
 # Definition of a portable crash-context that can be shared between various
 # crates
-crash-context = { version = "0.5", path = "../crash-context" }
+crash-context = "0.5"
 # Wrapper around libc
 libc = "0.2"
 # Nicer sync primitives

--- a/crash-handler/tests/abort.rs
+++ b/crash-handler/tests/abort.rs
@@ -1,14 +1,3 @@
-//! Abort is not catchable by a SEH, at least when done via the `__fastfail`
-//! instrinsic which is used by eg. `std::process::abort()`
-//!
-//! > Critical failures that may have corrupted program state and stack beyond
-//! > recovery cannot be handled by the regular exception handling facility.
-//! > Use __fastfail to terminate the process using minimal overhead.
-//!
-//! See <https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail?view=msvc-170>
-//! for more information
-#![cfg(unix)]
-
 mod shared;
 
 #[test]

--- a/crash-handler/tests/shared.rs
+++ b/crash-handler/tests/shared.rs
@@ -68,6 +68,7 @@ pub fn handles_crash(flavor: SadnessFlavor) {
                         use ch::ExceptionCode;
 
                         let ec = match flavor {
+                            SadnessFlavor::Abort => ExceptionCode::Abort,
                             SadnessFlavor::DivideByZero => ExceptionCode::Fpe,
                             SadnessFlavor::Illegal => ExceptionCode::Illegal,
                             SadnessFlavor::InvalidParameter => ExceptionCode::InvalidParameter,

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,10 @@ skip = [
     # The crate is in the repo, so we have the path, but it's also a crates.io
     # dependency
     { name = "crash-context" },
+
+    # crossbeam-epoch uses an old version
+    { name = "memoffset", version = "=0.6.5" },
+
     # range-map uses an old version, and is unfortunately unmaintained and has
     # not seen a release in 5 years
     { name = "num-traits", version = "=0.1.43" },

--- a/minidumper-test/crash-client/src/main.rs
+++ b/minidumper-test/crash-client/src/main.rs
@@ -73,7 +73,6 @@ fn real_main() -> anyhow::Result<()> {
                 Signal::Trap => {
                     sadness_generator::raise_trap();
                 }
-                #[cfg(unix)]
                 Signal::Abort => {
                     sadness_generator::raise_abort();
                 }

--- a/minidumper-test/tests/abort.rs
+++ b/minidumper-test/tests/abort.rs
@@ -1,14 +1,3 @@
-//! Abort is not catchable by a SEH, at least when done via the __fastfail
-//! instrinsic which is used by eg. `std::process::abort()`
-//!
-//! > Critical failures that may have corrupted program state and stack beyond
-//! > recovery cannot be handled by the regular exception handling facility.
-//! > Use __fastfail to terminate the process using minimal overhead.
-//!
-//! See <https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail?view=msvc-170>
-//! for more information
-#![cfg(unix)]
-
 use minidumper_test::*;
 
 #[test]

--- a/minidumper/Cargo.toml
+++ b/minidumper/Cargo.toml
@@ -24,7 +24,7 @@ libc = "0.2"
 # Basic log emitting
 log = "0.4"
 # Minidump writing
-minidump-writer = "0.5"
+minidump-writer = "0.6"
 # Event loop
 polling = "2.2"
 # Nicer locking primitives
@@ -41,7 +41,7 @@ uds = "0.2.6"
 scroll = "0.11"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.42" # Keep aligned with parking_lot & minidump-writer & crash-handler
+version = "0.42" # Keep aligned with parking_lot & crash-handler
 features = [
     "Win32_Foundation",         # Core types eg HANDLE
     "Win32_Networking_WinSock", # Sockets

--- a/minidumper/Cargo.toml
+++ b/minidumper/Cargo.toml
@@ -19,12 +19,12 @@ keywords = ["crash", "minidump", "ipc", "out-of-process"]
 [dependencies]
 # Nicer cfg handling
 cfg-if = "1.0"
-crash-context = "0.4"
+crash-context = "0.5"
 libc = "0.2"
 # Basic log emitting
 log = "0.4"
 # Minidump writing
-minidump-writer = "0.6"
+minidump-writer = "0.7"
 # Event loop
 polling = "2.2"
 # Nicer locking primitives
@@ -40,14 +40,10 @@ uds = "0.2.6"
 # Nicer binary interop
 scroll = "0.11"
 
-[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.42" # Keep aligned with parking_lot & crash-handler
-features = [
-    "Win32_Foundation",         # Core types eg HANDLE
-    "Win32_Networking_WinSock", # Sockets
-    "Win32_System_IO",          # Sockets
-    "Win32_System_Threading",   # OpenProcess
-]
+# Bindings to Win32
+[target.'cfg(target_os = "windows")'.dependencies.winapi]
+version = "0.3"
+features = ["handleapi", "winbase", "winsock2"]
 
 [dev-dependencies]
 # Diskwrite example
@@ -55,4 +51,3 @@ crash-handler = { path = "../crash-handler" }
 pretty_env_logger = "0.4.0"
 # uuid generation
 uuid = { version = "1.0", features = ["v4"] }
-backtrace = "0.3"

--- a/minidumper/src/ipc.rs
+++ b/minidumper/src/ipc.rs
@@ -31,7 +31,7 @@ cfg_if::cfg_if! {
             /// The id of the thread in the client process in which the crash originated
             thread_id: u32,
             /// The top level exception code, also found in the `EXCEPTION_POINTERS.ExceptionRecord.ExceptionCode`
-            exception_code: i32,
+            exception_code: u32,
         }
     } else if #[cfg(target_os = "macos")] {
         mod mac;

--- a/minidumper/src/ipc/server.rs
+++ b/minidumper/src/ipc/server.rs
@@ -272,7 +272,7 @@ impl Server {
                                             // the client process, and inform the dump writer that they are pointers
                                             // to a different process, as MiniDumpWriteDump will internally read
                                             // the processes memory as needed
-                                            let exception_pointers = dump_request.exception_pointers as *const std::ffi::c_void;
+                                            let exception_pointers = dump_request.exception_pointers as *const crash_context::ffi::EXCEPTION_POINTERS;
 
                                             let crash_ctx = crash_context::CrashContext {
                                                 exception_pointers,

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -67,7 +67,6 @@ impl SadnessFlavor {
     /// This is not safe. It intentionally crashes.
     pub unsafe fn make_sad(self) -> ! {
         match self {
-            #[cfg(unix)]
             Self::Abort => raise_abort(),
             Self::Segfault => raise_segfault(),
             Self::DivideByZero => raise_floating_point_exception(),

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -369,7 +369,12 @@ pub unsafe fn raise_stack_overflow_in_non_rust_thread_longjmp() -> ! {
 /// This is not safe. It intentionally crashes.
 #[cfg(target_os = "windows")]
 pub unsafe fn raise_purecall() -> ! {
-    asm!("call _purecall");
+    extern "C" {
+        fn _purecall() -> i32;
+    }
+
+    _purecall();
+
     std::process::abort()
 }
 

--- a/sadness-generator/src/lib.rs
+++ b/sadness-generator/src/lib.rs
@@ -8,14 +8,12 @@ use std::arch::asm;
 /// How you would like your sadness.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SadnessFlavor {
-    /// `SIGABRT` on Unix.
+    /// `SIGABRT`
     ///
-    /// This is not implemented on Windows as [`std::process::abort`], the
-    /// canonical way to abort processes in Rust, uses the [fastfail](
-    /// https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail?view=msvc-170)
+    /// Note that on Windows, [`std::process::abort`], the canonical way to
+    /// abort processes in Rust, uses the [fastfail](https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail?view=msvc-170)
     /// intrinsic, which neither raises a `SIGABRT` signal, nor issue a Windows
-    /// exception.
-    #[cfg(unix)]
+    /// exception. The method in this library always uses `libc::abort`
     Abort,
     /// * `SIGSEGV` on Linux
     /// * `EXCEPTION_ACCESS_VIOLATION` on Windows
@@ -109,10 +107,9 @@ impl SadnessFlavor {
 ///
 /// # Safety
 ///
-/// This is not safe. It intentionally crashes.
-#[cfg(unix)]
+/// This is not safe. It intentionally emits `SIGABRT`.
 pub unsafe fn raise_abort() -> ! {
-    std::process::abort()
+    libc::abort()
 }
 
 /// This is the fixed address used to generate a segfault. It's possible that


### PR DESCRIPTION
Follow up of #62.

Support  handling of `SIGABRT` on windows. While this is not generally useful in rust, due to `std::process::abort` using the fastfail mechanism which bypasses exception handling and signal emission, it is useful when there is C/C++ code involved, as, for example, `assert` will call `abort`.

This also replaces the `windows-sys` dependency  in `minidumper` with `winapi` as `window-sys` version churn has been incredibly annoying to deal with, and most projects still have `winapi` dependencies through other crates. This is probably temporary and we'll just write the bindings we need manually later since they aren't publicly exposed so there is no need to interoperate with other crates.

This also changes it so that sadness-generator now does `libc::abort` instead of `std::process::abort` so that all the platforms the crates in this repo support have the same signal based abort testing.