### PR TITLE
Fix the context definition for 32bit linux.

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -57,14 +57,16 @@ jobs:
     strategy:
       matrix:
         job:
-          - { target: aarch64-unknown-linux-gnu }
-          - { target: aarch64-unknown-linux-musl }
-          - { target: aarch64-linux-android }
+          - { target: aarch64-unknown-linux-gnu, toolchain: stable }
+          - { target: aarch64-unknown-linux-musl, toolchain: stable }
+          # workaround for https://github.com/cross-rs/cross/issues/1222
+          - { target: aarch64-linux-android, toolchain: "1.67.0" }
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ matrix.job.toolchain }}
           target: ${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Build

--- a/crash-context/src/linux.rs
+++ b/crash-context/src/linux.rs
@@ -131,7 +131,7 @@ cfg_if::cfg_if! {
         #[derive(Clone)]
         #[doc(hidden)]
         pub struct mcontext_t {
-            pub gregs: [i64; 23],
+            pub gregs: [i32; 23],
             pub fpregs: *mut fpregset_t,
             pub oldmask: u32,
             pub cr2: u32,

--- a/crash-context/src/mac/resource.rs
+++ b/crash-context/src/mac/resource.rs
@@ -185,7 +185,7 @@ impl CpuResourceException {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Cpu as u8);
 
         let flavor = Flavor::from(code);
-        let interval_seconds = ((code >> 7) & 0x1ffffff);
+        let interval_seconds = (code >> 7) & 0x1ffffff;
         let limit = (code & 0x7f) as u8;
         let consumed = subcode.map_or(0, |sc| sc & 0x7f) as u8;
 
@@ -262,7 +262,7 @@ impl WakeupsResourceException {
         let flavor = Flavor::from(code);
         // Note that Apple has a bug in exc_resource.h where the masks in the
         // decode macros for the interval and the permitted wakeups have been swapped
-        let interval_seconds = ((code >> 20) & 0xfff);
+        let interval_seconds = (code >> 20) & 0xfff;
         let permitted = (code & 0xfffff) as u32;
         let observed = subcode.map_or(0, |sc| sc & 0xfffff) as u32;
 
@@ -388,7 +388,7 @@ impl IoResourceException {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Io as u8);
 
         let flavor = Flavor::from(code);
-        let interval_seconds = ((code >> 15) & 0x1ffff);
+        let interval_seconds = (code >> 15) & 0x1ffff;
         let limit_mib = (code & 0x7fff) as u16;
         let observed_mib = subcode.map_or(0, |sc| sc & 0x7fff) as u16;
 

--- a/crash-context/src/mac/resource.rs
+++ b/crash-context/src/mac/resource.rs
@@ -185,7 +185,7 @@ impl CpuResourceException {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Cpu as u8);
 
         let flavor = Flavor::from(code);
-        let interval_seconds = ((code >> 7) & 0x1ffffff) as u64;
+        let interval_seconds = ((code >> 7) & 0x1ffffff);
         let limit = (code & 0x7f) as u8;
         let consumed = subcode.map_or(0, |sc| sc & 0x7f) as u8;
 
@@ -262,7 +262,7 @@ impl WakeupsResourceException {
         let flavor = Flavor::from(code);
         // Note that Apple has a bug in exc_resource.h where the masks in the
         // decode macros for the interval and the permitted wakeups have been swapped
-        let interval_seconds = ((code >> 20) & 0xfff) as u64;
+        let interval_seconds = ((code >> 20) & 0xfff);
         let permitted = (code & 0xfffff) as u32;
         let observed = subcode.map_or(0, |sc| sc & 0xfffff) as u32;
 
@@ -388,7 +388,7 @@ impl IoResourceException {
         debug_assert_eq!(resource_exc_kind(code), ResourceKind::Io as u8);
 
         let flavor = Flavor::from(code);
-        let interval_seconds = ((code >> 15) & 0x1ffff) as u64;
+        let interval_seconds = ((code >> 15) & 0x1ffff);
         let limit_mib = (code & 0x7fff) as u16;
         let observed_mib = subcode.map_or(0, |sc| sc & 0x7fff) as u16;
 

--- a/crash-handler/src/mac/state.rs
+++ b/crash-handler/src/mac/state.rs
@@ -135,7 +135,7 @@ impl HandlerInner {
 
         // Reset the condition variable in case a user signal was already raised
         {
-            let &(ref lock, ref _cvar) = &*self.user_signal;
+            let (lock, _cvar) = &*self.user_signal;
             *lock.lock() = None;
         }
 
@@ -157,7 +157,7 @@ impl HandlerInner {
         } else {
             // Wait on the handler thread to signal the user callback has finished
             // with the exception
-            let &(ref lock, ref cvar) = &*self.user_signal;
+            let (lock, cvar) = &*self.user_signal;
             let mut processed = lock.lock();
             if processed.is_none() {
                 cvar.wait(&mut processed);
@@ -511,7 +511,7 @@ unsafe fn exception_handler(port: mach_port_t, us: UserSignal) {
                 };
 
                 {
-                    let &(ref lock, ref cvar) = &*us;
+                    let (lock, cvar) = &*us;
                     let mut processed = lock.lock();
                     *processed = Some(matches!(res, CrashEventResult::Handled(true)));
                     cvar.notify_one();

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,12 @@ targets = [
 vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
-ignore = []
+ignore = [
+    # PR https://github.com/rust-minidump/rust-minidump/pull/826 already merged, just needs release
+    "RUSTSEC-2021-0153",
+    # Irrelevant, dev-only
+    "RUSTSEC-2021-0145",
+]
 
 [licenses]
 unlicensed = "deny"
@@ -32,12 +37,13 @@ skip = [
     # dependency
     { name = "crash-context" },
 
-    # crossbeam-epoch uses an old version
-    { name = "memoffset", version = "=0.6.5" },
-
-    # range-map uses an old version, and is unfortunately unmaintained and has
-    # not seen a release in 5 years
+    # minidump-writer uses old versions
+    { name = "memoffset", version = "=0.7.1" },
+    { name = "minidump-common", version = "=0.14.0" },
+    { name = "range-map", version = "=0.1.5" },
     { name = "num-traits", version = "=0.1.43" },
+
+    { name = "syn", version = "1.0" },
 ]
 skip-tree = []
 

--- a/minidumper-test/Cargo.toml
+++ b/minidumper-test/Cargo.toml
@@ -17,8 +17,8 @@ anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 cfg-if = "1.0"
 crash-handler = { path = "../crash-handler" }
-minidump = "0.14"
-minidump-common = "0.14"
+minidump = "0.15"
+minidump-common = "0.15"
 minidumper = { path = "../minidumper" }
 # This has some crazy dependencies, can enable manually if needed
 #notify-rust = "4.5"

--- a/minidumper-test/crash-client/Cargo.toml
+++ b/minidumper-test/crash-client/Cargo.toml
@@ -12,8 +12,8 @@ anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 cfg-if = "1.0"
 crash-handler = { path = "../../crash-handler" }
-minidump = "0.14"
-minidump-common = "0.14"
+minidump = "0.15"
+minidump-common = "0.15"
 minidumper = { path = "../../minidumper" }
 # This has some crazy dependencies, can enable manually if needed
 #notify-rust = "4.5"

--- a/minidumper/src/ipc/mac.rs
+++ b/minidumper/src/ipc/mac.rs
@@ -267,7 +267,7 @@ impl UnixStream {
 
     #[inline]
     pub(crate) fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.recv_with_flags(buf, libc::MSG_PEEK as i32)
+        self.0.recv_with_flags(buf, libc::MSG_PEEK)
     }
 
     #[inline]

--- a/minidumper/src/ipc/server.rs
+++ b/minidumper/src/ipc/server.rs
@@ -488,7 +488,7 @@ impl Drop for Server {
             // Note we don't check for the existence of the path since there
             // appears to be a bug on MacOS and Windows, or at least an oversight
             // in std, where checking the existence of the path always fails
-            let _res = std::fs::remove_file(&path);
+            let _res = std::fs::remove_file(path);
         }
     }
 }

--- a/minidumper/src/ipc/windows.rs
+++ b/minidumper/src/ipc/windows.rs
@@ -90,7 +90,7 @@ struct Socket(ws::SOCKET);
 impl Socket {
     pub fn new() -> io::Result<Socket> {
         // SAFETY: syscall
-        let socket = unsafe { ws::socket(ws::PF_UNIX as i32, ws::SOCK_STREAM as i32, 0) };
+        let socket = unsafe { ws::socket(ws::PF_UNIX, ws::SOCK_STREAM, 0) };
 
         if socket == ws::INVALID_SOCKET {
             Err(last_socket_error())
@@ -245,7 +245,7 @@ impl Drop for Socket {
         // SAFETY: syscalls
         let _ = unsafe {
             // https://docs.microsoft.com/en-us/windows/win32/winsock/graceful-shutdown-linger-options-and-socket-closure-2
-            if ws::shutdown(self.0, ws::SD_SEND /* 1 */ as i32) == 0 {
+            if ws::shutdown(self.0, ws::SD_SEND /* 1 */) == 0 {
                 // Loop until we've received all data
                 let mut chunk = [0u8; 1024];
                 while let Ok(sz) = self.recv_with_flags(&mut chunk, 0) {
@@ -275,7 +275,7 @@ impl UnixListener {
             ws::bind(
                 inner.as_raw_socket() as _,
                 (&addr.addr as *const sockaddr_un).cast(),
-                addr.len as i32,
+                addr.len,
             )
         } != 0
         {
@@ -345,7 +345,7 @@ impl UnixStream {
             ws::connect(
                 inner.as_raw_socket() as _,
                 (&addr.addr as *const sockaddr_un).cast(),
-                addr.len as i32,
+                addr.len,
             )
         } != 0
         {
@@ -357,7 +357,7 @@ impl UnixStream {
 
     #[inline]
     pub(crate) fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.recv_with_flags(buf, ws::MSG_PEEK as i32)
+        self.0.recv_with_flags(buf, ws::MSG_PEEK)
     }
 
     #[inline]


### PR DESCRIPTION
`i64` rather than `i32` was accidentally used for the general registers.

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The x86 context general registers have been changed to be `i32`.