### PR TITLE
Fix using `crash-handler` under Miri

### DIFF
--- a/crash-handler/src/unix.rs
+++ b/crash-handler/src/unix.rs
@@ -3,4 +3,5 @@ mod pthread_interpose;
 // Force this function to be linked, but it shouldn't actually be called by
 // users directly as it interposes the libc `pthread_create`
 #[doc(hidden)]
+#[cfg(not(miri))]
 pub use pthread_interpose::pthread_create;


### PR DESCRIPTION
This resolves a Linux compile error when building projects for Miri that uses the `crash-handler` crate.

Belive Miri shims `pthread_create` so we can't do it ourselves, and as the purpose of running with Miri is to run tests in an interpreted sandbox we don't need the crash handler there but it is the easiest if it can compile to avoid having special configurations in all usages.

Here is an example of the Miri compile error one ran into without this (from `cargo +nightly miri nextest run -p ark-svc-auto-proxy`):

```
error: found `pthread_create` symbol definition that clashes with a built-in shim
   --> /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/thread.rs:87:19
    |
87  |         let ret = libc::pthread_create(&mut native, &attr, thread_start, p as *mut _);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `pthread_create` symbol definition that clashes with a built-in shim
    |
help: the `pthread_create` symbol is defined here
   --> /home/repi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crash-handler-0.6.0/src/unix/pthread_interpose.rs:52:1
    |
52  | / pub extern "C" fn pthread_create(
53  | |     thread: *mut libc::pthread_t,
54  | |     attr: *const libc::pthread_attr_t,
55  | |     main: pthread_main_t,
...   |
107 | |     result
108 | | }
    | |_^
    = note: BACKTRACE (of the first span):
    = note: inside `std::sys::unix::thread::Thread::new` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/thread.rs:87:19: 87:86
    = note: inside `std::thread::Builder::spawn_unchecked_::<'_, '_, [closure@test::run_test::run_test_inner::{closure#1}], ()>` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:563:17: 568:18
    = note: inside `std::thread::Builder::spawn_unchecked::<'_, [closure@test::run_test::run_test_inner::{closure#1}], ()>` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:457:32: 457:62
    = note: inside `std::thread::Builder::spawn::<[closure@test::run_test::run_test_inner::{closure#1}], ()>` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:389:18: 389:41
    = note: inside `test::run_test::run_test_inner` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:599:19: 599:80
    = note: inside `test::run_test` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:642:28: 648:10
    = note: inside `test::run_tests::<[closure@test::run_tests_console::{closure#2}]>` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:380:31: 380:98
    = note: inside `test::run_tests_console` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/console.rs:329:5: 329:70
    = note: inside `test::test_main` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:139:15: 139:55
    = note: inside `test::test_main_static` at /home/repi/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:158:5: 158:40
    = note: inside `main`

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to previous error
```
