### PR TITLE
Add Android support for the i686 and x86-64 targets to the crash-context crate

### DIFF
--- a/crash-context/README.md
+++ b/crash-context/README.md
@@ -21,19 +21,21 @@
 
 ## Supported targets
 
-- `x86_64-unknown-linux-gnu`
-- `x86_64-unknown-linux-musl`
-- `i686-unknown-linux-gnu`
-- `i686-unknown-linux-musl`
+- `aarch64-android-linux`
+- `aarch64-apple-darwin`
 - `aarch64-unknown-linux-gnu`
 - `aarch64-unknown-linux-musl`
-- `aarch64-android-linux`
 - `arm-linux-androideabi`
 - `arm-unknown-linux-gnueabi`
 - `arm-unknown-linux-musleabi`
-- `x86_64-pc-windows-msvc`
+- `i686-linux-android`
+- `i686-unknown-linux-gnu`
+- `i686-unknown-linux-musl`
 - `x86_64-apple-darwin`
-- `aarch64-apple-darwin`
+- `x86_64-linux-android`
+- `x86_64-pc-windows-msvc`
+- `x86_64-unknown-linux-gnu`
+- `x86_64-unknown-linux-musl`
 
 ## Contribution
 

--- a/crash-context/src/linux/getcontext/x86.rs
+++ b/crash-context/src/linux/getcontext/x86.rs
@@ -1,53 +1,68 @@
-#[cfg(target_os = "android")]
-compile_error!("please file an issue if you care about this target");
+// Unfortunately, the asm! macro has a few really annoying limitations at the
+// moment
+//
+// 1. const operands are unstable
+// 2. cfg attributes can't be used inside the asm macro at all
+//
+// and the worst part is we need it for literally only 1 thing, using a different
+// offset to the fpstate in ucontext depending on whether we are targeting android
+// or not :(
+macro_rules! asm_func {
+    ($offset:expr) => {
+        std::arch::global_asm! {
+            ".text",
+            ".global crash_context_getcontext",
+            ".hidden crash_context_getcontext",
+            ".align 4",
+            ".type crash_context_getcontext, @function",
+        "crash_context_getcontext:",
+            "movl 4(%esp), %eax",   // eax = uc
 
-std::arch::global_asm! {
-    ".text",
-    ".global crash_context_getcontext",
-    ".hidden crash_context_getcontext",
-    ".align 4",
-    ".type crash_context_getcontext, @function",
-"crash_context_getcontext:",
-    "movl 4(%esp), %eax",   // eax = uc
+            // Save register values
+            "movl %ecx, 0x3c(%eax)",
+            "movl %edx, 0x38(%eax)",
+            "movl %ebx, 0x34(%eax)",
+            "movl %edi, 0x24(%eax)",
+            "movl %esi, 0x28(%eax)",
+            "movl %ebp, 0x2c(%eax)",
 
-    // Save register values
-    "movl %ecx, 0x3c(%eax)",
-    "movl %edx, 0x38(%eax)",
-    "movl %ebx, 0x34(%eax)",
-    "movl %edi, 0x24(%eax)",
-    "movl %esi, 0x28(%eax)",
-    "movl %ebp, 0x2c(%eax)",
+            "movl (%esp), %edx",   /* return address */
+            "lea  4(%esp), %ecx",  /* exclude return address from stack */
+            "mov  %edx, 0x4c(%eax)",
+            "mov  %ecx, 0x30(%eax)",
 
-    "movl (%esp), %edx",   /* return address */
-    "lea  4(%esp), %ecx",  /* exclude return address from stack */
-    "mov  %edx, 0x4c(%eax)",
-    "mov  %ecx, 0x30(%eax)",
+            "xorl %ecx, %ecx",
+            "movw %fs, %cx",
+            "mov  %ecx, 0x18(%eax)",
 
-    "xorl %ecx, %ecx",
-    "movw %fs, %cx",
-    "mov  %ecx, 0x18(%eax)",
+            "movl $0, 0x40(%eax)",
 
-    "movl $0, 0x40(%eax)",
+            // Save floating point state to fpregstate, then update
+            // the fpregs pointer to point to it
+            stringify!(leal $offset(%eax),%ecx),
+            "fnstenv (%ecx)",
+            "fldenv  (%ecx)",
+            "mov %ecx, 0x60(%eax)",
 
-    // Save floating point state to fpregstate, then update
-    // the fpregs pointer to point to it
-    "leal 0xec(%eax), %ecx",
-    "fnstenv (%ecx)",
-    "fldenv  (%ecx)",
-    "mov %ecx, 0x60(%eax)",
+            // Save signal mask: sigprocmask(SIGBLOCK, NULL, &uc->uc_sigmask)
+            "leal 0x6c(%eax), %edx",
+            "xorl %ecx, %ecx",
+            "push %edx",   /* &uc->uc_sigmask */
+            "push %ecx",   /* NULL */
+            "push %ecx",   /* SIGBLOCK == 0 on i386 */
+            "call sigprocmask@PLT",
+            "addl $12, %esp",
 
-    // Save signal mask: sigprocmask(SIGBLOCK, NULL, &uc->uc_sigmask)
-    "leal 0x6c(%eax), %edx",
-    "xorl %ecx, %ecx",
-    "push %edx",   /* &uc->uc_sigmask */
-    "push %ecx",   /* NULL */
-    "push %ecx",   /* SIGBLOCK == 0 on i386 */
-    "call sigprocmask@PLT",
-    "addl $12, %esp",
+            "movl $0, %eax",
+            "ret",
 
-    "movl $0, %eax",
-    "ret",
-
-    ".size crash_context_getcontext, . - crash_context_getcontext",
-    options(att_syntax)
+            ".size crash_context_getcontext, . - crash_context_getcontext",
+            options(att_syntax)
+        }
+    };
 }
+
+#[cfg(target_os = "linux")]
+asm_func!(0xec);
+#[cfg(target_os = "android")]
+asm_func!(0x74);

--- a/crash-context/src/linux/getcontext/x86_64.rs
+++ b/crash-context/src/linux/getcontext/x86_64.rs
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 // adding certain lines/blocks of asm based using cfg https://github.com/rust-lang/rust/issues/15701
 // and they're not really inputs, just literals, so...yah
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 
 // Unfortunately, the asm! macro has a few really annoying limitations at the
 // moment


### PR DESCRIPTION
### Checklist

* [✓] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [✓] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [✓] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR adds Android support for the i686 and x86-64 targets. This is largely used within emulators for testing. Note that I didn't add the architectures as supported in the top-level `README.md` file because I am still in the process of stabilizing Android support in the `minidump-writer` crate. Once that's done adding support within the crate should be trivial.

### Related Issues

N/A