### PR TITLE
riscv64: fix release mode compilation

### DIFF
--- a/crash-context/src/linux/getcontext/riscv64.rs
+++ b/crash-context/src/linux/getcontext/riscv64.rs
@@ -4,6 +4,7 @@
 
 std::arch::global_asm! {
     ".text",
+    ".attribute arch, \"rv64gc\"",
     ".globl crash_context_getcontext",
     ".hidden crash_context_getcontext",
     ".type crash_context_getcontext, @function",


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

A bug in LLVM (https://github.com/rust-lang/rust/issues/80608) has caused RISC-V assembler to produce "missing extension" errors (which seems to have become fatal in recent versions) on release build, which I overlooked. A workaround is to add explicit `rv64gc` declaration to the inline assembly, despite riscv64 Linux's target triple already contains `riscv64gc-*`.

### Related Issues

None