### PR TITLE
fix building with dynamically linked musl

### DIFF
--- a/crash-handler/src/unix/pthread_interpose.rs
+++ b/crash-handler/src/unix/pthread_interpose.rs
@@ -28,7 +28,7 @@ struct PthreadCreateParams {
 /// in the `pthread_key` destructor
 static mut THREAD_DESTRUCTOR_KEY: libc::pthread_key_t = 0;
 
-#[cfg(all(target_env = "musl", not(miri)))]
+#[cfg(all(target_env = "musl", target_feature = "crt-static", not(miri)))]
 unsafe extern "C" {
     /// This is the weak alias for `pthread_create`. We declare this so we can
     /// use its address when targeting musl, as we can't lookup the actual
@@ -66,7 +66,7 @@ pub extern "C" fn pthread_create(
     // used to uninstall and unmap the alternate stack
     INIT.call_once(|| unsafe {
         cfg_if::cfg_if! {
-            if #[cfg(target_env = "musl")] {
+            if #[cfg(all(target_env = "musl", target_feature = "crt-static"))] {
                 let ptr = __pthread_create as *mut c_void;
             } else {
                 const RTLD_NEXT: *mut c_void = -1isize as *mut c_void;


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The workaround of musl is only needed if musl is static linked, and don't work when musl is dynamically linked.

```
> readelf -s /usr/lib/libc.a | grep pthread_create
    47: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND pthread_create
    30: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND pthread_create
    24: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND pthread_create
File: /usr/lib/libc.a(pthread_create.lo)
     1: 0000000000000000     0 FILE    LOCAL  DEFAULT   ABS pthread_create.c
    12: 0000000000000000     0 SECTION LOCAL  DEFAULT    14 .text.__pthread_create
    57: 0000000000000000  1765 FUNC    GLOBAL HIDDEN     14 __pthread_create
    81: 0000000000000000  1765 FUNC    WEAK   DEFAULT    14 pthread_create
    12: 0000000000000000     0 NOTYPE  GLOBAL HIDDEN    UND __pthread_create
    28: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT   UND pthread_create
> readelf -s /usr/lib/libc.so | grep pthread_create
  1507: 00000000000b29d0  1765 FUNC    WEAK   DEFAULT    11 pthread_create
  1811: 0000000000000000     0 FILE    LOCAL  DEFAULT   ABS pthread_create.c
  1822: 00000000000b29d0  1765 FUNC    LOCAL  HIDDEN     11 __pthread_create
  2217: 00000000000b29d0  1765 FUNC    WEAK   DEFAULT    11 pthread_create
```

Just use the `dlsym` path when musl is dynamically linked.

### Related Issues

None
