### PR TITLE
crash-context: Account for Mach msg trailer in ack

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,7 +15,7 @@ rustflags = [
     "-Wclippy::dbg_macro",
     "-Wclippy::debug_assert_with_mut_call",
     "-Wclippy::doc_markdown",
-    "-Wclippy::empty_enum",
+    "-Wclippy::empty_enums",
     "-Wclippy::enum_glob_use",
     "-Wclippy::exit",
     "-Wclippy::expl_impl_clone_on_copy",

--- a/crash-context/src/mac/ipc.rs
+++ b/crash-context/src/mac/ipc.rs
@@ -236,7 +236,8 @@ impl Client {
                 head: MachMsgHeader {
                     bits: msg::MACH_MSG_TYPE_COPY_SEND | msg::MACH_MSGH_BITS_COMPLEX,
                     // We don't send the trailer, that's added by the kernel
-                    size: std::mem::size_of::<CrashContextMessage>() as u32 - std::mem::size_of::<MachMsgTrailer>() as u32,
+                    size: std::mem::size_of::<CrashContextMessage>() as u32
+                        - std::mem::size_of::<MachMsgTrailer>() as u32,
                     remote_port: self.port,
                     local_port: port::MACH_PORT_NULL,
                     voucher_port: port::MACH_PORT_NULL,
@@ -442,7 +443,8 @@ impl Acknowledger {
                 let mut msg = AcknowledgementMessage {
                     head: MachMsgHeader {
                         bits: msg::MACH_MSG_TYPE_COPY_SEND,
-                        size: std::mem::size_of::<AcknowledgementMessage>() as u32 - std::mem::size_of::<MachMsgTrailer>() as u32,
+                        size: std::mem::size_of::<AcknowledgementMessage>() as u32
+                            - std::mem::size_of::<MachMsgTrailer>() as u32,
                         remote_port: port,
                         local_port: port::MACH_PORT_NULL,
                         voucher_port: port::MACH_PORT_NULL,

--- a/crash-context/src/mac/ipc.rs
+++ b/crash-context/src/mac/ipc.rs
@@ -99,7 +99,7 @@ struct CrashContextMessage {
     /// The optional exception subcode
     exception_subcode: u64,
     /// We don't actually send this, but it's tacked on by the kernel :(
-    trailer: MachMsgTrailer,
+    _trailer: MachMsgTrailer,
 }
 
 const FLAG_HAS_EXCEPTION: u32 = 0x1;
@@ -110,6 +110,7 @@ const FLAG_HAS_SUBCODE: u32 = 0x2;
 struct AcknowledgementMessage {
     head: MachMsgHeader,
     result: u32,
+    _trailer: MachMsgTrailer,
 }
 
 /// An error that can occur while interacting with mach ports
@@ -235,7 +236,7 @@ impl Client {
                 head: MachMsgHeader {
                     bits: msg::MACH_MSG_TYPE_COPY_SEND | msg::MACH_MSGH_BITS_COMPLEX,
                     // We don't send the trailer, that's added by the kernel
-                    size: std::mem::size_of::<CrashContextMessage>() as u32 - 8,
+                    size: std::mem::size_of::<CrashContextMessage>() as u32 - std::mem::size_of::<MachMsgTrailer>() as u32,
                     remote_port: self.port,
                     local_port: port::MACH_PORT_NULL,
                     voucher_port: port::MACH_PORT_NULL,
@@ -257,7 +258,7 @@ impl Client {
                 exception_subcode,
                 // We don't actually send this but I didn't feel like making
                 // two types
-                trailer: MachMsgTrailer { kind: 0, size: 8 },
+                _trailer: MachMsgTrailer { kind: 0, size: 8 },
             };
 
             // Try to actually send the message to the Server
@@ -441,13 +442,14 @@ impl Acknowledger {
                 let mut msg = AcknowledgementMessage {
                     head: MachMsgHeader {
                         bits: msg::MACH_MSG_TYPE_COPY_SEND,
-                        size: std::mem::size_of::<AcknowledgementMessage>() as u32,
+                        size: std::mem::size_of::<AcknowledgementMessage>() as u32 - std::mem::size_of::<MachMsgTrailer>() as u32,
                         remote_port: port,
                         local_port: port::MACH_PORT_NULL,
                         voucher_port: port::MACH_PORT_NULL,
                         id: 0,
                     },
                     result: ack,
+                    _trailer: MachMsgTrailer { kind: 0, size: 8 },
                 };
 
                 // Try to actually send the message
@@ -529,6 +531,7 @@ impl AckReceiver {
                     id: 0,
                 },
                 result: 0,
+                _trailer: MachMsgTrailer { kind: 0, size: 8 },
             };
 
             // Wait for a response from the Server

--- a/crash-handler/src/linux/state.rs
+++ b/crash-handler/src/linux/state.rs
@@ -239,7 +239,7 @@ pub unsafe fn install_handlers() {
             libc::sigaddset(&mut sa.sa_mask, sig as i32);
         }
 
-        sa.sa_sigaction = signal_handler as usize;
+        sa.sa_sigaction = signal_handler as *const () as usize;
         sa.sa_flags = libc::SA_ONSTACK | libc::SA_SIGINFO;
 
         // Use our signal_handler for all of the signals we wish to catch
@@ -322,14 +322,14 @@ unsafe extern "C" fn signal_handler(
             {
                 let mut cur_handler = mem::zeroed();
                 if libc::sigaction(sig as i32, ptr::null_mut(), &mut cur_handler) == 0
-                    && cur_handler.sa_sigaction == signal_handler as usize
+                    && cur_handler.sa_sigaction == signal_handler as *const () as usize
                     && cur_handler.sa_flags & libc::SA_SIGINFO == 0
                 {
                     // Reset signal handler with the correct flags.
                     libc::sigemptyset(&mut cur_handler.sa_mask);
                     libc::sigaddset(&mut cur_handler.sa_mask, sig as i32);
 
-                    cur_handler.sa_sigaction = signal_handler as usize;
+                    cur_handler.sa_sigaction = signal_handler as *const () as usize;
                     cur_handler.sa_flags = libc::SA_ONSTACK | libc::SA_SIGINFO;
 
                     if libc::sigaction(sig as i32, &cur_handler, ptr::null_mut()) == -1 {

--- a/crash-handler/src/mac/signal.rs
+++ b/crash-handler/src/mac/signal.rs
@@ -12,7 +12,7 @@ pub(crate) unsafe fn install_abort_handler() -> Result<libc::sigaction, std::io:
         let mut sa: libc::sigaction = mem::zeroed();
         libc::sigemptyset(&mut sa.sa_mask);
         libc::sigaddset(&mut sa.sa_mask, libc::SIGABRT);
-        sa.sa_sigaction = signal_handler as usize;
+        sa.sa_sigaction = signal_handler as *const () as usize;
         sa.sa_flags = libc::SA_SIGINFO;
 
         let mut old_action = mem::MaybeUninit::uninit();

--- a/crash-handler/src/windows/signal.rs
+++ b/crash-handler/src/windows/signal.rs
@@ -10,7 +10,7 @@ pub(crate) unsafe fn install_abort_handler() -> Result<libc::sighandler_t, std::
     // It would be nice to use sigaction here since it's better, but it isn't
     // supported on Windows :p
     unsafe {
-        let old_handler = libc::signal(libc::SIGABRT, signal_handler as usize);
+        let old_handler = libc::signal(libc::SIGABRT, signal_handler as *const () as usize);
         if old_handler != usize::MAX {
             Ok(old_handler)
         } else {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Previously `AcknowledgementMessage` would not take the trailer (`mach_message_trailer_t`) into account causing a Mach kernel error

```rust
PortError(
        Message(
            268451844,
        ),
    ),
```

which corresponds to `MACH_RCV_TOO_LARGE` (`0x10004004`). The fix matches what is already done for `CrashContextMessage`.
