### PR TITLE
Bump minidump-writer to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,12 +296,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c942e64b20ecd39933d5ff938ca4fdb6ef0d298cc3855b231179a5ef0b24948d"
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,15 +442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minidump"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,7 +452,7 @@ dependencies = [
  "memmap2",
  "minidump-common",
  "num-traits",
- "procfs-core",
+ "procfs-core 0.17.0",
  "prost",
  "range-map",
  "scroll",
@@ -494,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "minidump-writer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1fc14d6ded915b8e850801465e7096f77ed60bf87e4e85878d463720d9dc4d"
+checksum = "48ef5778fc71c10d6bac1ec6b971ba0cc4b67cd8f3f0f7689dfdaab75884082f"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -509,14 +494,12 @@ dependencies = [
  "log",
  "mach2",
  "memmap2",
- "memoffset",
  "minidump-common",
  "nix",
- "procfs-core",
+ "procfs-core 0.18.0",
  "scroll",
  "serde",
  "serde_json",
- "tempfile",
  "thiserror",
 ]
 
@@ -557,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -693,6 +676,16 @@ name = "procfs-core"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags",
+ "hex",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags",
  "hex",
@@ -940,19 +933,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
-dependencies = [
- "fastrand",
- "getrandom",
- "once_cell",
- "rustix",
- "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 
 [profile.dev]
 debug = 2

--- a/minidumper/Cargo.toml
+++ b/minidumper/Cargo.toml
@@ -21,7 +21,7 @@ libc.workspace = true
 # Basic log emitting
 log = "0.4"
 # Minidump writing
-minidump-writer = "0.11"
+minidump-writer = "0.12"
 # Event loop
 polling = "3.2"
 # Nicer locking primitives


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Bumps `minidump-writer` from `0.11` to `0.12` in the `minidumper` crate.

**Motivation:** downstream consumers (in my case, a project chained through `sentry-rust-minidump` → `minidumper-child` → `minidumper`) end up with two versions of `nix` in their dependency graph — `0.29` pulled in via `minidump-writer 0.11`, and `0.30` used by the rest of the workspace. `minidump-writer 0.12` bumped its `nix` dependency to `^0.30` (rust-minidump/minidump-writer#172), so picking it up here unifies that transitive duplicate and lets us drop a `cargo-deny` skip entry.

### Related Issues

None directly, but this is the natural follow-up to #103 (the 0.10 → 0.11 bump).