### PR TITLE
Make alternate signal stack teardown non-fatal

### DIFF
--- a/crash-handler/CHANGELOG.md
+++ b/crash-handler/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#118](https://github.com/EmbarkStudios/crash-handling/pull/118) made alternate signal stack teardown non-fatal on Linux/Android.
+- [PR#118](https://github.com/EmbarkStudios/crash-handling/pull/118) fixed `mmap` failure check to compare against `MAP_FAILED` rather than null.
+
 ## [0.7.0] - 2026-01-13
 ### Fixed
 - [PR#105](https://github.com/EmbarkStudios/crash-handling/pull/105) fixed pthread interposition when statically linking `musl`.

--- a/crash-handler/src/unix/pthread_interpose.rs
+++ b/crash-handler/src/unix/pthread_interpose.rs
@@ -165,8 +165,9 @@ unsafe extern "C" fn set_alt_signal_stack_and_start(params: *mut c_void) -> *mut
 ///
 /// # Errors
 ///
-/// If we're able to map memory, but unable to install the alternate stack, we
-/// expect that we can unmap the memory
+/// Returns `null` if memory can't be mapped or the alternate stack can't be
+/// installed; a failed cleanup `munmap` is logged and the mapping leaked rather
+/// than treated as fatal.
 unsafe fn install_sig_alt_stack() -> *mut libc::c_void {
     let alt_stack_mem = unsafe {
         libc::mmap(

--- a/crash-handler/src/unix/pthread_interpose.rs
+++ b/crash-handler/src/unix/pthread_interpose.rs
@@ -180,8 +180,8 @@ unsafe fn install_sig_alt_stack() -> *mut libc::c_void {
     };
 
     // Check that we successfully mapped some memory
-    if alt_stack_mem.is_null() {
-        return alt_stack_mem;
+    if alt_stack_mem == libc::MAP_FAILED {
+        return ptr::null_mut();
     }
 
     let alt_stack = libc::stack_t {
@@ -195,11 +195,12 @@ unsafe fn install_sig_alt_stack() -> *mut libc::c_void {
 
     // Attempt to cleanup the mapping if we failed to install the alternate stack
     if rv != 0 {
-        assert_eq!(
-            unsafe { libc::munmap(alt_stack_mem, SIG_STACK_SIZE) },
-            0,
-            "failed to install an alternate signal stack, and failed to unmap the alternate stack memory"
-        );
+        if unsafe { libc::munmap(alt_stack_mem, SIG_STACK_SIZE) } != 0 {
+            eprintln!(
+                "failed to install an alternate signal stack, and failed to unmap the alternate stack memory: {}",
+                std::io::Error::last_os_error()
+            );
+        }
         ptr::null_mut()
     } else {
         alt_stack_mem
@@ -210,8 +211,8 @@ unsafe fn install_sig_alt_stack() -> *mut libc::c_void {
 ///
 /// # Errors
 ///
-/// If the alternate stack is not `null`, it is expected that uninstalling and
-/// unmapping will not error
+/// If the alternate stack is not `null`, uninstalling and unmapping may
+/// still error; such errors are logged rather than fatal
 #[unsafe(no_mangle)]
 unsafe extern "C" fn uninstall_sig_alt_stack(alt_stack_mem: *mut libc::c_void) {
     if alt_stack_mem.is_null() {
@@ -224,15 +225,21 @@ unsafe extern "C" fn uninstall_sig_alt_stack(alt_stack_mem: *mut libc::c_void) {
         ss_size: 0,
     };
 
-    // Attempt to uninstall the alternate stack
-    assert_eq!(
-        unsafe { libc::sigaltstack(&disable_stack, ptr::null_mut()) },
-        0,
-        "failed to uninstall alternate signal stack"
-    );
-    assert_eq!(
-        unsafe { libc::munmap(alt_stack_mem, SIG_STACK_SIZE) },
-        0,
-        "failed to unmap alternate stack memory"
-    );
+    // If disabling fails the kernel may still reference this memory as the
+    // active alternate stack (e.g. EPERM when it's in use), so deliberately
+    // leak the mapping rather than unmap a stack the kernel will still use.
+    if unsafe { libc::sigaltstack(&disable_stack, ptr::null_mut()) } != 0 {
+        eprintln!(
+            "failed to uninstall alternate signal stack: {}",
+            std::io::Error::last_os_error()
+        );
+        return;
+    }
+
+    if unsafe { libc::munmap(alt_stack_mem, SIG_STACK_SIZE) } != 0 {
+        eprintln!(
+            "failed to unmap alternate stack memory: {}",
+            std::io::Error::last_os_error()
+        );
+    }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR logs sigaltstack/munmap failures instead of panicking. The kernel may still reference the mapping as the active alternate stack, so unmapping would leave a dangling stack.

Also included a drive-by fix for the mmap failure check to compare against `MAP_FAILED` rather than `null` (mmap never returns null on failure, so this check was dead anyway).

### Related Issues

N/A
